### PR TITLE
Slightly expand retrieved data

### DIFF
--- a/Anilist4Net.Test/MediaTests.cs
+++ b/Anilist4Net.Test/MediaTests.cs
@@ -56,7 +56,13 @@ namespace Anilist4Net.Test
 			IsNotEmpty(media.MediaRelations
 			                .Where(r => r.MediaId == 5 && r.RelationType == MediaRelationType.SIDE_STORY)
 			                .ToArray());
+			AreEqual("Cowboy Bebop: The Movie - Knockin' on Heaven's Door", media.Relations.Edges.First().Node.Title.English);
+            AreEqual("カウボーイビバップ天国の扉", media.Relations.Edges.First().Node.Title.Native);
+            AreEqual("Cowboy Bebop: Tengoku no Tobira", media.Relations.Edges.First().Node.Title.Romaji);
 			Contains(1, media.MediaCharacters);
+
+			AreEqual(CharacterRole.MAIN, media.Characters.Edges.First().Role);
+
 			IsNotEmpty(media.Staff.Edges.Select(e => e.Node.Id == 95269 && e.Role == "ADR Director"));
 			IsNotEmpty(media.Studios.Edges.Select(e => e.Node.Id == 14 && e.IsMain));
 			IsFalse(media.IsAdult);

--- a/Anilist4Net.Test/StaffTests.cs
+++ b/Anilist4Net.Test/StaffTests.cs
@@ -29,6 +29,8 @@ namespace Anilist4Net.Test
 			IsEmpty(staff.CharacterIds);
 			IsEmpty(staff.CharacterMediaIds);
 			IsNull(staff.ModNotes);
+			AreEqual("https://s4.anilist.co/file/anilistcdn/staff/large/3152.jpg", staff.ImageLarge);
+            AreEqual("https://s4.anilist.co/file/anilistcdn/staff/medium/3152.jpg", staff.ImageMedium);
 		}
 	}
 }

--- a/Anilist4Net/Client.cs
+++ b/Anilist4Net/Client.cs
@@ -122,6 +122,11 @@ namespace Anilist4Net
       edges {
         node {
           id
+          title {
+            romaji
+            english
+            native
+          }
         }
         relationType
       }
@@ -131,6 +136,7 @@ namespace Anilist4Net
         node {
           id
         }
+        role
         voiceActors {
           id
         }
@@ -331,6 +337,10 @@ namespace Anilist4Net
 		nodes {
 			id
 		}
+	}
+	image {
+		large
+		medium
 	}
 	favourites
 	modNotes

--- a/Anilist4Net/Connections.cs
+++ b/Anilist4Net/Connections.cs
@@ -15,7 +15,8 @@ namespace Anilist4Net.Connections
 
 	public class MediaNodePlaceholder
 	{
-		public int Id { get; set; }
+		public int Id           { get; set; }
+		public MediaTitle Title { get; set; }
 	}
 
 	public class CharacterConnection
@@ -27,11 +28,12 @@ namespace Anilist4Net.Connections
 	{
 		public CharacterNodePlaceholder Node        { get; set; }
 		public VoiceActorPlaceholder[]  VoiceActors { get; set; }
-	}
+        public CharacterRole Role                   { get; set; }
+    }
 
 	public class CharacterNodePlaceholder
 	{
-		public int Id { get; set; }
+		public int Id      { get; set; }
 	}
 
 	public class VoiceActorPlaceholder

--- a/Anilist4Net/Enums.cs
+++ b/Anilist4Net/Enums.cs
@@ -129,4 +129,11 @@ namespace Anilist4Net.Enums
 		RATED,
 		POPULAR
 	}
+
+    public enum CharacterRole
+    {
+        MAIN,
+        SUPPORTING,
+        BACKGROUND
+	}
 }

--- a/Anilist4Net/Staff.cs
+++ b/Anilist4Net/Staff.cs
@@ -66,6 +66,18 @@ namespace Anilist4Net
 		/// </summary>
 		public int Favourites { get; set; }
 
+		public StaffImage Image { get; set; }
+
+        /// <summary>
+        ///     The staff's image URL (large)
+        /// </summary>
+        public string ImageLarge => Image.Large;
+
+        /// <summary>
+        ///     The staff's image URL (medium)
+        /// </summary>
+        public string ImageMedium => Image.Medium;
+
 		/// <summary>
 		///     Mods Notes
 		/// </summary>
@@ -76,4 +88,10 @@ namespace Anilist4Net
 	{
 		public Staff Staff { get; set; }
 	}
+
+    public class StaffImage
+    {
+        public string Large { get; set; }
+        public string Medium { get; set; }
+    }
 }


### PR DESCRIPTION
I just added one or two additional fields that I use when retrieving Media entries.
I also added the image URLs when retrieving a staff entry.

- Relationship edge nodes now also include the title of the relationship
- Character edge now contains the character's role
- Staff retrieval now also retrieves the staff image URLs