### PR TITLE
Media type differentiation for MAL Id retrieval

### DIFF
--- a/Anilist4Net.Test/MediaTests.cs
+++ b/Anilist4Net.Test/MediaTests.cs
@@ -99,7 +99,7 @@ namespace Anilist4Net.Test
 		// Caters for cases where there are more than one Mal Id that is the same (for example an anime and a manga) by allowing the user to specify the media type they expect
         [TestCase(MediaTypes.ANIME, "Yakusoku no Neverland 2")]
         [TestCase(MediaTypes.MANGA, "Vermillion")]
-		public async Task SettingExpectedMediaTypeCorrectlyDifferentiateMatchingMalIds(MediaTypes typeToRetrieve, string expectedTitle)
+		public async Task MalIdByTypeTest(MediaTypes typeToRetrieve, string expectedTitle)
         {
             var media = await client.GetMediaByMalId(39617, typeToRetrieve);
             AreEqual(typeToRetrieve, media.Type);

--- a/Anilist4Net.Test/MediaTests.cs
+++ b/Anilist4Net.Test/MediaTests.cs
@@ -95,5 +95,15 @@ namespace Anilist4Net.Test
 			IsNotNull(media.StartDate.ToDate());
 			AreEqual(new DateTime(2009, 1, 1, 0, 0, 0, DateTimeKind.Unspecified), media.StartDate.ToDate());
 		}
+
+		// Caters for cases where there are more than one Mal Id that is the same (for example an anime and a manga) by allowing the user to specify the media type they expect
+        [TestCase(MediaTypes.ANIME, "Yakusoku no Neverland 2")]
+        [TestCase(MediaTypes.MANGA, "Vermillion")]
+		public async Task SettingExpectedMediaTypeCorrectlyDifferentiateMatchingMalIds(MediaTypes typeToRetrieve, string expectedTitle)
+        {
+            var media = await client.GetMediaByMalId(39617, typeToRetrieve);
+            AreEqual(typeToRetrieve, media.Type);
+			AreEqual(expectedTitle, media.RomajiTitle);
+        }
 	}
 }

--- a/Anilist4Net/Client.cs
+++ b/Anilist4Net/Client.cs
@@ -416,7 +416,25 @@ namespace Anilist4Net
 
 			return response.Data.Media;
 		}
-		
+
+        public async Task<Media> GetMediaByMalId(int id, MediaTypes mediaType)
+        {
+            var query = $"query ($id: Int) {{ Media (idMal: $id type: {mediaType}) {MediaQueryReturn} }}";
+            var request = new GraphQLRequest { Query = query, Variables = new { id } };
+            GraphQLResponse<MediaResponse> response = null!;
+            try
+            {
+                response = await graphQlClient.SendQueryAsync<MediaResponse>(request);
+            }
+            catch (GraphQLHttpRequestException e)
+            {
+                if (e.StatusCode == HttpStatusCode.NotFound)
+                    return null; // media did not exist
+            }
+
+            return response.Data.Media;
+		}
+
 		public async Task<Media> GetMediaBySearch(string search)
 		{
 			var query         = $"query ($search: String) {{ Media (search: $search) {MediaQueryReturn} }}";


### PR DESCRIPTION
In some cases a Mal Id can link to multiple media entries on AniList
(See [Neverland S2](https://myanimelist.net/anime/39617). It's Id for Media type `Anime` links to [Neverland S2](https://anilist.co/edit/anime/108725) and for Media type `Manga` to [Vermillion](https://anilist.co/edit/manga/69617)

This request adds a method to the Client that allows the user to specify the media type when requesting an entry by Mal Id