### PR TITLE
JSon conversion fix

### DIFF
--- a/Anilist4Net/Media.cs
+++ b/Anilist4Net/Media.cs
@@ -172,7 +172,7 @@ namespace Anilist4Net
 		/// <summary>
 		///     The true mean average score
 		/// </summary>
-		public int MeanScore { get; set; }
+		public int? MeanScore { get; set; }
 
 		/// <summary>
 		///     How popular the media is


### PR DESCRIPTION
Fixed an issue where Media's MeanScore can be null which causes a retrieval to fail.

Sorry, there is no test for this one. If you want to check you can use [https://anilist.co/anime/107717/Kobayashisan-Chi-no-Maidragon-S/](Kobayashi-san Chi no Maidragon S), but cannot add as a test as once it gets a mean score the test will fail.