### PR TITLE
Data paging

### DIFF
--- a/Anilist4Net.Test/CharacterTests.cs
+++ b/Anilist4Net.Test/CharacterTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Anilist4Net.Enums;
 using NUnit.Framework;
 using static NUnit.Framework.Assert;
 
@@ -26,6 +28,20 @@ namespace Anilist4Net.Test
 			Contains(40827, character.MediaIds);
 			IsNull(character.ModNotes);
 		}
+
+        [Test]
+        public async Task RolesInMedia()
+        {
+			// arrange
+            var client = new Client();
+
+			// act
+            var character = await client.GetCharacterById(215834);
+
+			// assert
+            AreEqual(CharacterRole.MAIN, character.Media.Edges.First(x => x.Node.Id == 135381).CharacterRole);
+            AreEqual(CharacterRole.SUPPORTING, character.Media.Edges.First(x => x.Node.Id == 129814).CharacterRole);
+        }
 
 		[Test]
 		public async Task NagisaShiotaBySearchTest() // I'm having trouble hiding my biases here.

--- a/Anilist4Net.Test/CharacterTests.cs
+++ b/Anilist4Net.Test/CharacterTests.cs
@@ -65,5 +65,20 @@ namespace Anilist4Net.Test
 			Contains(69883, character.MediaIds);
 			IsNull(character.ModNotes);
 		}
+
+		// Ensure we retrieve all the media pages and not just the first 25
+		[Test]
+		public async Task NarutoMedia()
+        {
+			// arrange
+			var client = new Client();
+
+			// act
+			var character = await client.GetCharacterById(17);
+
+			// assert
+			GreaterOrEqual(character.Media.Edges.Length, 52);
+			GreaterOrEqual(character.Media.Nodes.Length, 52);
+		}
 	}
 }

--- a/Anilist4Net.Test/MediaTests.cs
+++ b/Anilist4Net.Test/MediaTests.cs
@@ -105,5 +105,18 @@ namespace Anilist4Net.Test
             AreEqual(typeToRetrieve, media.Type);
 			AreEqual(expectedTitle, media.RomajiTitle);
         }
+
+		// Check the relationship types for ZombieLand Saga to ensure anime/manga type is correctly returned
+        [Test]
+        public async Task RelationshipMediaType()
+        {
+			// arrange
+			// act
+            var media = await client.GetMediaById(103871);
+
+			// assert
+			AreEqual(MediaTypes.MANGA, media.Relations.Edges.First(x => x.Node.Id == 104714).Node.Type);
+            AreEqual(MediaTypes.ANIME, media.Relations.Edges.First(x => x.Node.Id == 110733).Node.Type);
+		}
 	}
 }

--- a/Anilist4Net.Test/MediaTests.cs
+++ b/Anilist4Net.Test/MediaTests.cs
@@ -61,7 +61,7 @@ namespace Anilist4Net.Test
             AreEqual("Cowboy Bebop: Tengoku no Tobira", media.Relations.Edges.First().Node.Title.Romaji);
 			Contains(1, media.MediaCharacters);
 
-			AreEqual(CharacterRole.MAIN, media.Characters.Edges.First().Role);
+			AreEqual(CharacterRole.MAIN, media.Characters.Edges.First(x => x.Node.Id == 1).Role);
 
 			IsNotEmpty(media.Staff.Edges.Select(e => e.Node.Id == 95269 && e.Role == "ADR Director"));
 			IsNotEmpty(media.Studios.Edges.Select(e => e.Node.Id == 14 && e.IsMain));
@@ -118,5 +118,16 @@ namespace Anilist4Net.Test
 			AreEqual(MediaTypes.MANGA, media.Relations.Edges.First(x => x.Node.Id == 104714).Node.Type);
             AreEqual(MediaTypes.ANIME, media.Relations.Edges.First(x => x.Node.Id == 110733).Node.Type);
 		}
+
+        [Test]
+		public async Task SpiderCharacters()
+        {
+			// arrange
+			// act
+			var media = await client.GetMediaById(103632);
+
+			// assert
+			AreEqual(42, media.Characters.Edges.Length);
+        }
 	}
 }

--- a/Anilist4Net.Test/StaffTests.cs
+++ b/Anilist4Net.Test/StaffTests.cs
@@ -35,7 +35,7 @@ namespace Anilist4Net.Test
 		}
 
         [Test]
-        public async Task StaffMedia()
+        public async Task StaffCharacters()
         {
 			// arrange
             var client = new Client();
@@ -44,9 +44,9 @@ namespace Anilist4Net.Test
 			var staff = await client.GetStaffById(101686);
 
 			// assert
-			GreaterOrEqual(25, staff.Characters.Edges.Length);
+			GreaterOrEqual(staff.Characters.Edges.Length, 164);
             var edge = staff.Characters.Edges.First(x => x.Node.Id == 38904);
             AreEqual(MediaTypes.ANIME, edge.Node.Media.Nodes.First(x => x.Id == 9776).Type);
-        }
+        }		
 	}
 }

--- a/Anilist4Net.Test/StaffTests.cs
+++ b/Anilist4Net.Test/StaffTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Threading.Tasks;
 using Anilist4Net.Enums;
 using NUnit.Framework;
 using static NUnit.Framework.Assert;
@@ -32,5 +33,20 @@ namespace Anilist4Net.Test
 			AreEqual("https://s4.anilist.co/file/anilistcdn/staff/large/3152.jpg", staff.ImageLarge);
             AreEqual("https://s4.anilist.co/file/anilistcdn/staff/medium/3152.jpg", staff.ImageMedium);
 		}
+
+        [Test]
+        public async Task StaffMedia()
+        {
+			// arrange
+            var client = new Client();
+
+			// act
+			var staff = await client.GetStaffById(101686);
+
+			// assert
+			GreaterOrEqual(25, staff.Characters.Edges.Length);
+            var edge = staff.Characters.Edges.First(x => x.Node.Id == 38904);
+            AreEqual(MediaTypes.ANIME, edge.Node.Media.Nodes.First(x => x.Id == 9776).Type);
+        }
 	}
 }

--- a/Anilist4Net/Anilist4Net.csproj
+++ b/Anilist4Net/Anilist4Net.csproj
@@ -7,6 +7,12 @@
 	<Authors>Cain Atkinson</Authors>
 	<Company></Company>
 	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+	<AssemblyVersion>1.3.0.0</AssemblyVersion>
+	<FileVersion>1.3.0.0</FileVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DocumentationFile>bin\Release\netstandard2.1\Anilist4Net.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Anilist4Net/Character.cs
+++ b/Anilist4Net/Character.cs
@@ -80,7 +80,7 @@ namespace Anilist4Net
 		///     Mods Notes
 		/// </summary>
 		public string ModNotes { get; set; }
-	}
+    }
 
 	public class CharacterResponse
 	{

--- a/Anilist4Net/Client.cs
+++ b/Anilist4Net/Client.cs
@@ -7,372 +7,30 @@ using Anilist4Net.Enums;
 using System.Net.Http;
 using System;
 using System.Net;
+using Anilist4Net.Connections;
+using System.Collections.Generic;
 
 namespace Anilist4Net
 {
+	/// <summary>
+	/// Client used to handle retrieval of data from AniList Graph API
+	/// </summary>
 	public class Client
 	{
-        #region GraphQL Queries
-        private static readonly string UserQueryReturn = @"{
-	id
-	name
-	aboutMd: about(asHtml: false)
-	aboutHtml:about(asHtml: true)
-	avatar {
-		large
-		medium
-	}
-	bannerImage
-	options {
-		titleLanguage
-		displayAdultContent
-		airingNotifications
-		profileColor
-	}
-	mediaListOptions {
-		scoreFormat
-		rowOrder
-		animeList {
-				sectionOrder
-				splitCompletedSectionByFormat
-				customLists
-				advancedScoring
-				advancedScoringEnabled
-			}
-		mangaList {
-			sectionOrder
-			splitCompletedSectionByFormat
-			customLists
-			advancedScoring
-			advancedScoringEnabled
-		}
-	}
-	unreadNotificationCount
-	siteUrl
-	donatorTier
-	donatorBadge
-	moderatorStatus
-	updatedAt
-}";
-
-		private static readonly string MediaQueryReturn = @"{
-    id
-    idMal
-    title {
-      romaji
-      english
-      native
-    }
-    type
-    format
-    status(version: 2)
-    descriptionMd: description(asHtml: false)
-    descriptionHtml: description(asHtml: true)
-    startDate {
-      year
-      month
-      day
-    }
-    endDate {
-      year
-      month
-      day
-    }
-    season
-    seasonYear
-    seasonInt
-    episodes
-    duration
-    chapters
-    volumes
-    countryOfOrigin
-    isLicensed
-    source(version: 2)
-    hashtag
-    trailer {
-      id
-      site
-      thumbnail
-    }
-    updatedAt
-    coverImage {
-      extraLarge
-      large
-      medium
-      color
-    }
-    bannerImage
-    genres
-    synonyms
-    averageScore
-    meanScore
-    popularity
-    isLocked
-    trending
-    favourites
-    tags {
-      id
-      name
-      description
-      category
-      rank
-      isGeneralSpoiler
-      isMediaSpoiler
-      isAdult
-    }
-    relations {
-      edges {
-        node {
-          id
-          title {
-            romaji
-            english
-            native
-          }
-          type
-        }
-        relationType
-      }
-    }
-    characters {
-      edges {
-        node {
-          id
-        }
-        role
-        voiceActors {
-          id
-        }
-      }
-    }
-    staff {
-      edges {
-        node {
-          id
-        }
-        role
-      }
-    }
-    studios {
-      edges {
-        node {
-          id
-        }
-        isMain
-      }
-    }
-    isAdult
-    nextAiringEpisode {
-      id
-      airingAt
-      timeUntilAiring
-      episode
-      mediaId
-    }
-    airingSchedule {
-      nodes {
-        id
-        airingAt
-        timeUntilAiring
-        episode
-        mediaId
-      }
-    }
-    trends {
-      nodes {
-        mediaId
-        date
-        trending
-        averageScore
-        popularity
-        inProgress
-        releasing
-        episode
-      }
-    }
-    externalLinks {
-      id
-      url
-      site
-    }
-    streamingEpisodes {
-      title
-      thumbnail
-      url
-      site
-    }
-    rankings {
-      id
-      rank
-      type
-      format
-      year
-      season
-      allTime
-      context
-    }
-    reviews {
-      nodes {
-        id
-      }
-    }
-    recommendations {
-      nodes {
-        id
-      }
-    }
-    stats {
-      scoreDistribution {
-        score
-        amount
-      }
-      statusDistribution {
-        status
-        amount
-      }
-    }
-    siteUrl
-    autoCreateForumThread
-    isRecommendationBlocked
-    modNotes
-}";
-
-		private static readonly string ReviewQueryReturn = @"{
-		id
-		userId
-		mediaId
-		mediaType
-		summary
-		bodyMd: body(asHtml: false)
-		bodyHtml: body(asHtml: true)
-		rating
-		ratingAmount
-		score
-		private
-		siteUrl
-		createdAt
-		updatedAt
-}";
-
-		private static readonly string AiringScheduleQueryReturn = @"{
-	id
-	airingAt
-	timeUntilAiring
-	episode
-	mediaId
-}";
-
-		private static readonly string RecommendationQueryReturn = @"{
-	id
-	rating
-	media {
-		id
-	}
-	mediaRecommendation {
-		id
-	}
-	user {
-		id
-	}
-}";
-
-		private static readonly string CharacterQueryReturn = @"{
-	id
-	name {
-		first
-		last
-		full
-		native
-		alternative
-	}
-	image {
-		large
-		medium
-	}
-	descriptionMd: description(asHtml: false)
-	descriptionHtml: description(asHtml: true)
-	siteUrl
-	media { 
-		nodes {
-			id
-            type
-		}
-        edges {
-            node {
-                id
-            }
-            characterRole
-        }
-	}
-	favourites
-	modNotes
-}";
-
-		private static readonly string StudioQueryReturn = @"{
-	id
-	name
-	isAnimationStudio
-	media{
-		nodes{
-			id
-		}
-	}
-	siteUrl
-	favourites
-}";
-
-		private static readonly string StaffQueryReturn = @"{
-	id
-	name {
-		first
-		last
-		full
-		native
-	}
-	language
-	descriptionMd: description(asHtml: false)
-	descriptionHtml: description(asHtml: true)
-	siteUrl
-	staffMedia {
-		nodes {
-			id
-		}
-	}
-	characters {
-        edges{
-            node{
-                id,
-                name {
-                    first
-                    last
-            }
-            media {
-                nodes{
-                    id
-                    type              
-                }
-            }
-        }
-    }
-	}
-	characterMedia {
-		nodes {
-			id
-		}
-	}
-	image {
-		large
-		medium
-	}
-	favourites
-	modNotes
-}";
-		#endregion
-
+		/// <summary>
+		/// GraphQLHttpClient instance
+		/// </summary>
 		private readonly GraphQLHttpClient graphQlClient;
 
+		/// <summary>
+		/// Default Constructor
+		/// </summary>
 		public Client() : this(new HttpClient()) { }
 
+		/// <summary>
+		/// Construct with a <see cref="HttpClient"/> instance
+		/// </summary>
+		/// <param name="httpClient">Client instance to use for queries</param>
 		public Client(HttpClient httpClient)
 		{
 			var options = new GraphQLHttpClientOptions
@@ -383,32 +41,56 @@ namespace Anilist4Net
 		}
 
         #region Query Invocations
+
+		/// <summary>
+		/// Retrieve a <see cref="User"/> by their username
+		/// </summary>
+		/// <param name="username">Username of the user to retrieve</param>
+		/// <returns>User data</returns>
         public async Task<User> GetUserByName(string username)
 		{
-			var query         = $"query ($username: String) {{ User (name: $username) {UserQueryReturn} }}";
+			var query         = $"query ($username: String) {{ User (name: $username) {QueryBuilder.GetUserQuery()} }}";
 			var request       = new GraphQLRequest {Query = query, Variables = new {username}};
 			var response      = await graphQlClient.SendQueryAsync<UserResponse>(request);
 
 			return response.Data.User;
 		}
 
+		/// <summary>
+		/// Retrieve a <see cref="User"/> by their AniList Id
+		/// </summary>
+		/// <param name="id">user's AniList Id</param>
+		/// <returns>User data</returns>
 		public async Task<User> GetUserById(int id)
 		{
-			var query         = $"query ($id: Int) {{ User (id: $id) {UserQueryReturn} }}";
+			var query         = $"query ($id: Int) {{ User (id: $id) {QueryBuilder.GetUserQuery()} }}";
 			var request       = new GraphQLRequest {Query = query, Variables = new {id}};
 			var response      = await graphQlClient.SendQueryAsync<UserResponse>(request);
 
 			return response.Data.User;
 		}
 
+		/// <summary>
+		/// Retrieve a <see cref="Media"/> entry by its AniList Id
+		/// </summary>
+		/// <param name="id">AniList media Id</param>
+		/// <returns>Media instance if it exists, otherwise null</returns>
 		public async Task<Media?> GetMediaById(int id)
 		{
-			var query         = $"query ($id: Int) {{ Media (id: $id) {MediaQueryReturn} }}";
+			var query         = $"query ($id: Int) {{ Media (id: $id) {QueryBuilder.GetMediaQuery()} }}";
 			var request       = new GraphQLRequest {Query = query, Variables = new {id}};
 			GraphQLResponse<MediaResponse> response = null!;
 			try
 			{
 				response = await graphQlClient.SendQueryAsync<MediaResponse>(request);
+				var characterCount = response.Data.Media.Characters.Edges.Length;
+				if(characterCount >= 25)
+                {
+					var additionalCharacters = await GetAllCharactersAsync(id, 2);
+					additionalCharacters.AddRange(response.Data.Media.Characters.Edges);
+					response.Data.Media.Characters.Edges = additionalCharacters.ToArray();
+                }
+
 			}
 			catch (GraphQLHttpRequestException e)
 			{
@@ -419,14 +101,31 @@ namespace Anilist4Net
 			return response.Data.Media;
 		}
 
-		public async Task<Media> GetMediaByMalId(int id)
+		/// <summary>
+		/// Retrieve a <see cref="Media"/> entry by its MyAnimeList Id.
+		/// <remarks>
+		///		If there is both a matching anime and manga entry for the provided MAL Id it is uncertain which entry will be returned.
+		///		To better control the response rather use the <see cref="GetMediaByMalId(int, MediaTypes)"/> method.
+		/// </remarks>
+		/// </summary>
+		/// <param name="id">MAL Id to retrieve entry for</param>
+		/// <returns>Media instance if one could be found, otherwise null</returns>
+		public async Task<Media?> GetMediaByMalId(int id)
 		{
-			var query         = $"query ($id: Int) {{ Media (idMal: $id) {MediaQueryReturn} }}";
+			var query         = $"query ($id: Int) {{ Media (idMal: $id) {QueryBuilder.GetMediaQuery()} }}";
 			var request       = new GraphQLRequest {Query = query, Variables = new {id}};
 			GraphQLResponse<MediaResponse> response = null!;
 			try
 			{
 				response = await graphQlClient.SendQueryAsync<MediaResponse>(request);
+				var characterCount = response.Data.Media.Characters.Edges.Length;
+				if (characterCount >= 25)
+				{
+					// Swap to the AniList Id rather than using the Mal Id
+					var additionalCharacters = await GetAllCharactersAsync(response.Data.Media.Id, 2);
+					additionalCharacters.AddRange(response.Data.Media.Characters.Edges);
+					response.Data.Media.Characters.Edges = additionalCharacters.ToArray();
+				}
 			}
 			catch (GraphQLHttpRequestException e)
 			{
@@ -437,15 +136,28 @@ namespace Anilist4Net
 			return response.Data.Media;
 		}
 
-        public async Task<Media> GetMediaByMalId(int id, MediaTypes mediaType)
+		/// <summary>
+		/// Retrieve a <see cref="Media"/> entry by its MyAnimeList Id and its AniList type
+		/// </summary>
+		/// <param name="id">MAL Id to retrieve entry for</param>
+		/// <param name="mediaType">The type of media to retrieve</param>
+		/// <returns>Media instance if one could be found, otherwise null</returns>
+		public async Task<Media?> GetMediaByMalId(int id, MediaTypes mediaType)
         {
-            var query = $"query ($id: Int) {{ Media (idMal: $id type: {mediaType}) {MediaQueryReturn} }}";
+            var query = $"query ($id: Int) {{ Media (idMal: $id type: {mediaType}) {QueryBuilder.GetMediaQuery()} }}";
             var request = new GraphQLRequest { Query = query, Variables = new { id } };
             GraphQLResponse<MediaResponse> response = null!;
             try
             {
                 response = await graphQlClient.SendQueryAsync<MediaResponse>(request);
-            }
+				var characterCount = response.Data.Media.Characters.Edges.Length;
+				if (characterCount >= 25)
+				{
+					var additionalCharacters = await GetAllCharactersAsync(id, 2);
+					additionalCharacters.AddRange(response.Data.Media.Characters.Edges);
+					response.Data.Media.Characters.Edges = additionalCharacters.ToArray();
+				}
+			}
             catch (GraphQLHttpRequestException e)
             {
                 if (e.StatusCode == HttpStatusCode.NotFound)
@@ -455,14 +167,26 @@ namespace Anilist4Net
             return response.Data.Media;
 		}
 
-		public async Task<Media> GetMediaBySearch(string search)
+		/// <summary>
+		/// Search for a <see cref="Media"/> entry by its title
+		/// </summary>
+		/// <param name="search">Search query</param>
+		/// <returns>Media instance if one could be found, otherwise null</returns>
+		public async Task<Media?> GetMediaBySearch(string search)
 		{
-			var query         = $"query ($search: String) {{ Media (search: $search) {MediaQueryReturn} }}";
+			var query         = $"query ($search: String) {{ Media (search: $search) {QueryBuilder.GetMediaQuery()} }}";
 			var request       = new GraphQLRequest {Query = query, Variables = new {search}};
 			GraphQLResponse<MediaResponse> response = null!;
 			try
 			{
 				response = await graphQlClient.SendQueryAsync<MediaResponse>(request);
+				var characterCount = response.Data.Media.Characters.Edges.Length;
+				if (characterCount >= 25)
+				{
+					var additionalCharacters = await GetAllCharactersAsync(response.Data.Media.Id, 2);
+					additionalCharacters.AddRange(response.Data.Media.Characters.Edges);
+					response.Data.Media.Characters.Edges = additionalCharacters.ToArray();
+				}
 			}
 			catch (GraphQLHttpRequestException e)
 			{
@@ -472,15 +196,28 @@ namespace Anilist4Net
 
 			return response.Data.Media;
 		}
-		
-		public async Task<Media> GetMediaBySearch(string search, MediaTypes type)
+
+		/// <summary>
+		/// Search for a <see cref="Media"/> entry by its title
+		/// </summary>
+		/// <param name="search">Search query</param>
+		/// <param name="type">The type of media to search for</param>
+		/// <returns>Media instance if one could be found, otherwise null</returns>
+		public async Task<Media?> GetMediaBySearch(string search, MediaTypes type)
 		{
-			var query         = $"query ($search: String $type: MediaType) {{ Media (search: $search type: $type) {MediaQueryReturn} }}";
+			var query         = $"query ($search: String $type: MediaType) {{ Media (search: $search type: $type) {QueryBuilder.GetMediaQuery()} }}";
 			var request       = new GraphQLRequest {Query = query, Variables = new {search, type}};
 			GraphQLResponse<MediaResponse> response = null!;
 			try
 			{
 				response = await graphQlClient.SendQueryAsync<MediaResponse>(request);
+				var characterCount = response.Data.Media.Characters.Edges.Length;
+				if (characterCount >= 25)
+				{
+					var additionalCharacters = await GetAllCharactersAsync(response.Data.Media.Id, 2);
+					additionalCharacters.AddRange(response.Data.Media.Characters.Edges);
+					response.Data.Media.Characters.Edges = additionalCharacters.ToArray();
+				}
 			}
 			catch (GraphQLHttpRequestException e)
 			{
@@ -491,86 +228,252 @@ namespace Anilist4Net
 			return response.Data.Media;
 		}
 
+		/// <summary>
+		/// Retrieve all characters for a <see cref="Media"/> entry.
+		/// </summary>
+		/// <param name="id">AniList media Id</param>
+		/// <param name="page">Page to start the retrieval from</param>
+		/// <returns>List of <see cref="CharacterEdge"/>s for the Media</returns>
+		public async Task<List<CharacterEdge>> GetAllCharactersAsync(int id, int page)
+		{
+			var characterCount = 0;
+			var characters = new List<CharacterEdge>();
+			do
+			{
+				try
+				{
+					var query = $"query ($id: Int) {{ Media (id: $id) {QueryBuilder.GetCharactersForMediaQuery(page)} }}";
+					var request = new GraphQLRequest { Query = query, Variables = new { id } };
+					var response = await graphQlClient.SendQueryAsync<MediaResponse>(request);
+					characterCount = response.Data.Media.Characters.Edges.Length;
+					characters.AddRange(response.Data.Media.Characters.Edges);
+					page++;
+				}
+				catch (Exception)
+				{
+					// What to do here? We don't really mind as we can just keep trying until the end
+				}
+			} while (characterCount >= 25);
+
+			return characters;
+		}
+
+		/// <summary>
+		/// Retrieve a <see cref="Review"/> by its AniList Id
+		/// </summary>
+		/// <param name="id">Id of the review to retrieve</param>
+		/// <returns>Review for the requested Id</returns>
 		public async Task<Review> GetReviewById(int id)
 		{
-			var query         = $"query ($id: Int) {{ Review (id: $id) {ReviewQueryReturn} }}";
+			var query         = $"query ($id: Int) {{ Review (id: $id) {QueryBuilder.GetReviewQuery()} }}";
 			var request       = new GraphQLRequest {Query = query, Variables = new {id}};
 			var response      = await graphQlClient.SendQueryAsync<ReviewResponse>(request);
 
 			return response.Data.Review;
 		}
 
+		/// <summary>
+		/// Retrieve an <see cref="AiringSchedule"/> entry by its AniList Id
+		/// </summary>
+		/// <param name="id">AniList Id of the schedule entry to retrieve</param>
+		/// <returns>AiringSchedule entry</returns>
 		public async Task<AiringSchedule> GetAiringScheduleById(int id)
 		{
-			var query         = $"query ($id: Int) {{ AiringSchedule (id: $id) {AiringScheduleQueryReturn} }}";
+			var query         = $"query ($id: Int) {{ AiringSchedule (id: $id) {QueryBuilder.GetAiringScheduleQuery()} }}";
 			var request       = new GraphQLRequest {Query = query, Variables = new {id}};
 			var response      = await graphQlClient.SendQueryAsync<AiringScheduleResponse>(request);
 
 			return response.Data.AiringSchedule;
 		}
 
+		/// <summary>
+		/// Retrieve a <see cref="Recommendation"/> entry by its AniList Id
+		/// </summary>
+		/// <param name="id">AniList Id of the recommendation to retrieve</param>
+		/// <returns>Recommendation entry</returns>
 		public async Task<Recommendation> GetRecommendationById(int id)
 		{
-			var query         = $"query ($id: Int) {{ Recommendation (id: $id) {RecommendationQueryReturn} }}";
+			var query         = $"query ($id: Int) {{ Recommendation (id: $id) {QueryBuilder.GetRecommendationQuery()} }}";
 			var request       = new GraphQLRequest {Query = query, Variables = new {id}};
 			var response      = await graphQlClient.SendQueryAsync<RecommendationResponse>(request);
 
 			return response.Data.Recommendation;
 		}
 
+		/// <summary>
+		/// Retrieve a <see cref="Character"/> entry by its AniList Id
+		/// </summary>
+		/// <param name="id">AniList Id of the character to retrieve</param>
+		/// <returns>Character entry</returns>
 		public async Task<Character> GetCharacterById(int id)
 		{
-			var query         = $"query ($id: Int) {{ Character (id: $id) {CharacterQueryReturn} }}";
+			var query         = $"query ($id: Int) {{ Character (id: $id) {QueryBuilder.GetCharacterQuery()} }}";
 			var request       = new GraphQLRequest {Query = query, Variables = new {id}};
 			var response      = await graphQlClient.SendQueryAsync<CharacterResponse>(request);
+
+			var mediaCount = response.Data.Character.Media.Edges.Length;
+			if (mediaCount >= 25)
+			{
+				var additionalMedia = await GetAllMediaEntriesForCharacter(id, 2);
+				additionalMedia.edges.AddRange(response.Data.Character.Media.Edges);
+				additionalMedia.nodes.AddRange(response.Data.Character.Media.Nodes);
+				response.Data.Character.Media.Edges = additionalMedia.edges.ToArray();
+				response.Data.Character.Media.Nodes = additionalMedia.nodes.ToArray();
+			}
 
 			return response.Data.Character;
 		}
 
+		/// <summary>
+		/// Retrieve all media entries for a <see cref="Character"/> entry.
+		/// </summary>
+		/// <param name="id">AniList character Id</param>
+		/// <param name="page">Page to start the retrieval from</param>
+		/// <returns>Tuple containing a list of <see cref="MediaEdge"/>s and <see cref="MediaNodePlaceholder"/>s for the <see cref="Character"/></returns>
+		public async Task<(List<CharacterEdge> edges, List<MediaNodePlaceholder> nodes)> GetAllMediaEntriesForCharacter(int id, int page)
+		{
+			var mediaCount = 0;
+			var edges = new List<CharacterEdge>();
+			var nodes = new List<MediaNodePlaceholder>();
+			do
+			{
+				try
+				{
+					var query = $"query ($id: Int) {{ Character (id: $id) {QueryBuilder.GetCharacterMediaQuery(page)} }}";
+					var request = new GraphQLRequest { Query = query, Variables = new { id } };
+					var response = await graphQlClient.SendQueryAsync<CharacterResponse>(request);
+					mediaCount = response.Data.Character.Media.Edges.Length;
+					edges.AddRange(response.Data.Character.Media.Edges);
+					nodes.AddRange(response.Data.Character.Media.Nodes);					
+					
+					page++;
+				}
+				catch (Exception)
+				{
+					// What to do here? We don't really mind as we can just keep trying until the end
+				}
+			} while (mediaCount >= 25);
+
+			return (edges, nodes);
+		}
+
+		/// <summary>
+		/// Search for a <see cref="Character"/>
+		/// </summary>
+		/// <param name="search">Search query</param>
+		/// <returns>Character matching the query</returns>
 		public async Task<Character> GetCharacterBySearch(string search)
 		{
-			var query         = $"query ($search: String) {{ Character (search: $search) {CharacterQueryReturn} }}";
+			var query         = $"query ($search: String) {{ Character (search: $search) {QueryBuilder.GetCharacterQuery()} }}";
 			var request       = new GraphQLRequest {Query = query, Variables = new {search}};
 			var response      = await graphQlClient.SendQueryAsync<CharacterResponse>(request);
 
 			return response.Data.Character;
 		}
 
+		/// <summary>
+		/// Retrieve a <see cref="Studio"/> by its AniList Id
+		/// </summary>
+		/// <param name="id">Studio Id</param>
+		/// <returns>Studio for the Id</returns>
 		public async Task<Studio> GetStudioById(int id)
 		{
-			var query         = $"query ($id: Int) {{ Studio (id: $id) {StudioQueryReturn} }}";
+			var query         = $"query ($id: Int) {{ Studio (id: $id) {QueryBuilder.GetStudioQuery()} }}";
 			var request       = new GraphQLRequest {Query = query, Variables = new {id}};
 			var response      = await graphQlClient.SendQueryAsync<StudioResponse>(request);
 
 			return response.Data.Studio;
 		}
 
+		/// <summary>
+		/// Search for a <see cref="Studio"/>
+		/// </summary>
+		/// <param name="search">Search query</param>
+		/// <returns>Studio entry mathing the search query</returns>
 		public async Task<Studio> GetStudioBySearch(string search)
 		{
-			var query         = $"query ($search: String) {{ Studio (search: $search) {StudioQueryReturn} }}";
+			var query         = $"query ($search: String) {{ Studio (search: $search) {QueryBuilder.GetStudioQuery()} }}";
 			var request       = new GraphQLRequest {Query = query, Variables = new {search}};
 			var response      = await graphQlClient.SendQueryAsync<StudioResponse>(request);
 
 			return response.Data.Studio;
 		}
 
+		/// <summary>
+		/// Retrieve a <see cref="Staff"/> entry from AniList
+		/// </summary>
+		/// <param name="id">Id of the staff entry to retrieve</param>
+		/// <returns>Staff entry for the Id</returns>
 		public async Task<Staff> GetStaffById(int id)
 		{
-			var query         = $"query ($id: Int) {{ Staff (id: $id) {StaffQueryReturn} }}";
+			var query         = $"query ($id: Int) {{ Staff (id: $id) {QueryBuilder.GetStaffQuery()} }}";
 			var request       = new GraphQLRequest {Query = query, Variables = new {id}};
 			var response      = await graphQlClient.SendQueryAsync<StaffResponse>(request);
 
+			var characterCount = response.Data.Staff.Characters.Edges.Length;
+			if (characterCount >= 25)
+			{
+				var additionalCharacters = await GetAllCharactersForStaffAsync(id, 2);
+				additionalCharacters.AddRange(response.Data.Staff.Characters.Edges);
+				response.Data.Staff.Characters.Edges = additionalCharacters.ToArray();
+			}
+
 			return response.Data.Staff;
 		}
 
+		/// <summary>
+		/// Search for a <see cref="Staff"/> entry
+		/// </summary>
+		/// <param name="search">Search query</param>
+		/// <returns>Staff entry matching the search</returns>
 		public async Task<Staff> GetStaffBySearch(string search)
 		{
-			var query         = $"query ($search: String) {{ Staff (search: $search) {StaffQueryReturn} }}";
+			var query         = $"query ($search: String) {{ Staff (search: $search) {QueryBuilder.GetStaffQuery()} }}";
 			var request       = new GraphQLRequest {Query = query, Variables = new {search}};
 			var response      = await graphQlClient.SendQueryAsync<StaffResponse>(request);
 
+			var characterCount = response.Data.Staff.Characters.Edges.Length;
+			if (characterCount >= 25)
+			{
+				var additionalCharacters = await GetAllCharactersForStaffAsync(response.Data.Staff.Id, 2);
+				additionalCharacters.AddRange(response.Data.Staff.Characters.Edges);
+				response.Data.Staff.Characters.Edges = additionalCharacters.ToArray();
+			}
+
 			return response.Data.Staff;
 		}
-        #endregion
-    }
+
+		/// <summary>
+		/// Retrieve all character entries for a <see cref="Staff"/> entry.
+		/// </summary>
+		/// <param name="id">AniList staff Id</param>
+		/// <param name="page">Page to start the retrieval from</param>
+		/// <returns>List of <see cref="MediaEdge"/>s for the <see cref="Staff"/></returns>
+		public async Task<List<CharacterEdge>> GetAllCharactersForStaffAsync(int id, int page)
+		{
+			var mediaCount = 0;
+			var edges = new List<CharacterEdge>();
+			do
+			{
+				try
+				{
+					var query = $"query ($id: Int) {{ Staff (id: $id) {QueryBuilder.GetStaffCharactersQuery(page)} }}";
+					var request = new GraphQLRequest { Query = query, Variables = new { id } };
+					var response = await graphQlClient.SendQueryAsync<StaffResponse>(request);
+					mediaCount = response.Data.Staff.Characters.Edges.Length;
+					edges.AddRange(response.Data.Staff.Characters.Edges);
+
+					page++;
+				}
+				catch (Exception)
+				{
+					// What to do here? We don't really mind as we can just keep trying until the end
+				}
+			} while (mediaCount >= 25);
+
+			return edges;
+		}
+
+		#endregion
+	}
 }

--- a/Anilist4Net/Client.cs
+++ b/Anilist4Net/Client.cs
@@ -90,7 +90,6 @@ namespace Anilist4Net
 					additionalCharacters.AddRange(response.Data.Media.Characters.Edges);
 					response.Data.Media.Characters.Edges = additionalCharacters.ToArray();
                 }
-
 			}
 			catch (GraphQLHttpRequestException e)
 			{

--- a/Anilist4Net/Client.cs
+++ b/Anilist4Net/Client.cs
@@ -129,6 +129,7 @@ namespace Anilist4Net
             english
             native
           }
+          type
         }
         relationType
       }
@@ -294,7 +295,14 @@ namespace Anilist4Net
 	media { 
 		nodes {
 			id
+            type
 		}
+        edges {
+            node {
+                id
+            }
+            characterRole
+        }
 	}
 	favourites
 	modNotes
@@ -331,9 +339,21 @@ namespace Anilist4Net
 		}
 	}
 	characters {
-		nodes {
-			id
-		}
+        edges{
+            node{
+                id,
+                name {
+                    first
+                    last
+            }
+            media {
+                nodes{
+                    id
+                    type              
+                }
+            }
+        }
+    }
 	}
 	characterMedia {
 		nodes {

--- a/Anilist4Net/Connections.cs
+++ b/Anilist4Net/Connections.cs
@@ -79,7 +79,7 @@ namespace Anilist4Net.Connections
 
 	public class AiringScheduleConnection
 	{
-		public AiringScheduleNodePlaceholder[] Nodes { get; set; }
+		public AiringSchedule[] Nodes { get; set; }
 	}
 
 	public class AiringScheduleNodePlaceholder

--- a/Anilist4Net/Connections.cs
+++ b/Anilist4Net/Connections.cs
@@ -11,12 +11,13 @@ namespace Anilist4Net.Connections
 	{
 		public MediaNodePlaceholder Node         { get; set; }
 		public MediaRelationType    RelationType { get; set; }
-	}
+    }
 
 	public class MediaNodePlaceholder
 	{
 		public int Id           { get; set; }
 		public MediaTitle Title { get; set; }
+		public MediaTypes? Type { get; set; }
 	}
 
 	public class CharacterConnection
@@ -28,12 +29,15 @@ namespace Anilist4Net.Connections
 	{
 		public CharacterNodePlaceholder Node        { get; set; }
 		public VoiceActorPlaceholder[]  VoiceActors { get; set; }
-        public CharacterRole Role                   { get; set; }
-    }
+        public CharacterRole? Role                  { get; set; }
+        public CharacterRole? CharacterRole         { get; set; }
+	}
 
 	public class CharacterNodePlaceholder
 	{
 		public int Id      { get; set; }
+		public MultiLanguageName Name { get; set; }
+		public MediaNodeConnection Media { get; set; }
 	}
 
 	public class VoiceActorPlaceholder
@@ -116,5 +120,6 @@ namespace Anilist4Net.Connections
 	public class MediaNodeConnection
 	{
 		public MediaNodePlaceholder[] Nodes { get; set; }
-	}
+		public CharacterEdge[] Edges { get; set; }
+    }
 }

--- a/Anilist4Net/QueryBuilder.cs
+++ b/Anilist4Net/QueryBuilder.cs
@@ -1,0 +1,501 @@
+﻿namespace Anilist4Net
+{
+    /// <summary>
+    /// Build queries used to retrieve data from AniList API
+    /// <see cref="https://anilist.co/graphiql?"/> for assistance with building queries
+    /// </summary>
+    public static class QueryBuilder
+    {
+        #region Queries
+
+        /// <summary>
+        /// Retrieve query that can be used to retrieve characters for a <see cref="Media"/> entry.
+        /// This query is useful for retrieving characters when a <see cref="Media"/> entry has more than 25 characters.
+        /// </summary>
+        /// <param name="page">The page of characters to retrieve. Page contains 25 entries</param>
+        /// <returns>Query to retrieve characters for Media</returns>
+        public static string GetCharactersForMediaQuery(int page)
+        {
+            return @"{
+                        " + CharacterQuery(page) + @"
+                    }";
+        }
+
+        /// <summary>
+        /// Retrieve query that can be used to retrieve media for a <see cref="Character"/> entry.
+        /// This query is useful for retrieving media when a <see cref="Character"/> entry has more than 25 media entries.
+        /// </summary>
+        /// <param name="page">The page of media entries to retrieve. Page contains 25 entries</param>
+        /// <returns>Query to retrieve media for a character</returns>
+        public static string GetCharacterMediaQuery(int page)
+        {
+            return @"{
+                        " + CharacterMediaQuery(page) + @"
+                    }";
+        }
+
+        /// <summary>
+        /// Retrieve query that can be used to retrieve <see cref="CharacterConnection"/> for a <see cref="Staff"/> entry
+        /// </summary>
+        /// <param name="page">The page of <see cref="CharacterConnection"/> entries to retrive. Page contains 25 entries</param>
+        /// <returns>Query to retrieve characters for a staff entry</returns>
+        public static string GetStaffCharactersQuery(int page)
+        {
+            return @"{
+                        " + CharactersForStaff(page) + @"
+                    }";
+        }
+
+        /// <summary>
+        /// Retrieve query that can be used to retrieve a complete <see cref="Media"/> entry.
+        /// </summary>
+        /// <returns>Query to retrieve <see cref="Media"/></returns>
+        public static string GetMediaQuery()
+        {
+            return @"{
+                        id
+                        idMal
+                        title {
+                          romaji
+                          english
+                          native
+                        }
+                        type
+                        format
+                        status(version: 2)
+                        descriptionMd: description(asHtml: false)
+                        descriptionHtml: description(asHtml: true)
+                        startDate {
+                          year
+                          month
+                          day
+                        }
+                        endDate {
+                          year
+                          month
+                          day
+                        }
+                        season
+                        seasonYear
+                        seasonInt
+                        episodes
+                        duration
+                        chapters
+                        volumes
+                        countryOfOrigin
+                        isLicensed
+                        source(version: 2)
+                        hashtag
+                        trailer {
+                          id
+                          site
+                          thumbnail
+                        }
+                        updatedAt
+                        coverImage {
+                          extraLarge
+                          large
+                          medium
+                          color
+                        }
+                        bannerImage
+                        genres
+                        synonyms
+                        averageScore
+                        meanScore
+                        popularity
+                        isLocked
+                        trending
+                        favourites
+                        tags {
+                          id
+                          name
+                          description
+                          category
+                          rank
+                          isGeneralSpoiler
+                          isMediaSpoiler
+                          isAdult
+                        }
+                        relations {
+                          edges {
+                            node {
+                              id
+                              title {
+                                romaji
+                                english
+                                native
+                              }
+                              type
+                            }
+                            relationType
+                          }
+                        }"
+                        + CharacterQuery(1) +
+                        @"staff {
+                          edges {
+                            node {
+                              id
+                            }
+                            role
+                          }
+                        }
+                        studios {
+                          edges {
+                            node {
+                              id
+                            }
+                            isMain
+                          }
+                        }
+                        isAdult
+                        nextAiringEpisode {
+                          id
+                          airingAt
+                          timeUntilAiring
+                          episode
+                          mediaId
+                        }
+                        airingSchedule {
+                          nodes {
+                            id
+                            airingAt
+                            timeUntilAiring
+                            episode
+                            mediaId
+                          }
+                        }
+                        trends {
+                          nodes {
+                            mediaId
+                            date
+                            trending
+                            averageScore
+                            popularity
+                            inProgress
+                            releasing
+                            episode
+                          }
+                        }
+                        externalLinks {
+                          id
+                          url
+                          site
+                        }
+                        streamingEpisodes {
+                          title
+                          thumbnail
+                          url
+                          site
+                        }
+                        rankings {
+                          id
+                          rank
+                          type
+                          format
+                          year
+                          season
+                          allTime
+                          context
+                        }
+                        reviews {
+                          nodes {
+                            id
+                          }
+                        }
+                        recommendations {
+                          nodes {
+                            id
+                          }
+                        }
+                        stats {
+                          scoreDistribution {
+                            score
+                            amount
+                          }
+                          statusDistribution {
+                            status
+                            amount
+                          }
+                        }
+                        siteUrl
+                        autoCreateForumThread
+                        isRecommendationBlocked
+                        modNotes
+                    }";
+        }
+
+        /// <summary>
+        /// Retrieve query that can be used to retrieve a <see cref="Studio"/>
+        /// </summary>
+        /// <returns>Query for retrieving a studio from AniList</returns>
+        public static string GetStudioQuery()
+        {
+            return @"{
+	                    id
+	                    name
+	                    isAnimationStudio
+	                    media{
+		                    nodes{
+			                    id
+		                    }
+	                    }
+	                    siteUrl
+	                    favourites
+                    }";
+        }
+
+        /// <summary>
+        /// Retrieve query that can be used to retrieve a <see cref="Recommendation"/>
+        /// </summary>
+        /// <returns>Query for retrieving a recommendation from AniList</returns>
+        public static string GetRecommendationQuery()
+        {
+            return @"{
+	                    id
+	                    rating
+	                    media {
+		                    id
+	                    }
+	                    mediaRecommendation {
+		                    id
+	                    }
+	                    user {
+		                    id
+	                    }
+                    }";
+        }
+
+        /// <summary>
+        /// Retrieve query that can be used to retrieve a <see cref="Review"/>
+        /// </summary>
+        /// <returns>Query for retrieving a review from AniList</returns>
+        public static string GetReviewQuery()
+        {
+            return @"{
+		                id
+		                userId
+		                mediaId
+		                mediaType
+		                summary
+		                bodyMd: body(asHtml: false)
+		                bodyHtml: body(asHtml: true)
+		                rating
+		                ratingAmount
+		                score
+		                private
+		                siteUrl
+		                createdAt
+		                updatedAt
+                }";
+        }
+
+        /// <summary>
+        /// Retrieve query that can be used to retrieve a <see cref="User"/>
+        /// </summary>
+        /// <returns>Query for retrieving a user from AniList</returns>
+        public static string GetUserQuery()
+        {
+            return @"{
+	                    id
+	                    name
+	                    aboutMd: about(asHtml: false)
+	                    aboutHtml:about(asHtml: true)
+	                    avatar {
+		                    large
+		                    medium
+	                    }
+	                    bannerImage
+	                    options {
+		                    titleLanguage
+		                    displayAdultContent
+		                    airingNotifications
+		                    profileColor
+	                    }
+	                    mediaListOptions {
+		                    scoreFormat
+		                    rowOrder
+		                    animeList {
+				                    sectionOrder
+				                    splitCompletedSectionByFormat
+				                    customLists
+				                    advancedScoring
+				                    advancedScoringEnabled
+			                    }
+		                    mangaList {
+			                    sectionOrder
+			                    splitCompletedSectionByFormat
+			                    customLists
+			                    advancedScoring
+			                    advancedScoringEnabled
+		                    }
+	                    }
+	                    unreadNotificationCount
+	                    siteUrl
+	                    donatorTier
+	                    donatorBadge
+	                    moderatorStatus
+	                    updatedAt
+                    }";
+        }
+
+        /// <summary>
+        /// Retrieve query that can be used to retrieve a <see cref="AiringSchedule"/>
+        /// </summary>
+        /// <returns>Query for retrieving an AiringSchedule from AniList</returns>
+        public static string GetAiringScheduleQuery()
+        {
+            return @"{
+	                    id
+	                    airingAt
+	                    timeUntilAiring
+	                    episode
+	                    mediaId
+                    }";
+        }
+
+        /// <summary>
+        /// Retrieve query that can be used to retrieve a <see cref="Character"/>
+        /// </summary>
+        /// <returns>Query for retrieving a character from AniList</returns>
+        public static string GetCharacterQuery()
+        {
+            return @"{
+	                    id
+	                    name {
+		                    first
+		                    last
+		                    full
+		                    native
+		                    alternative
+	                    }
+	                    image {
+		                    large
+		                    medium
+	                    }
+	                    descriptionMd: description(asHtml: false)
+	                    descriptionHtml: description(asHtml: true)
+	                    siteUrl
+                        "
+	                    + CharacterMediaQuery(1) +
+	                    @"
+                        favourites
+	                    modNotes
+                    }";
+        }
+
+        /// <summary>
+        /// Retrieve query that can be used to retrieve a <see cref="Staff"/> entry
+        /// </summary>
+        /// <returns>Query for retrieving <see cref="Staff"/> entry from AniList</returns>
+        public static string GetStaffQuery()
+        {
+            return @"{
+	                    id
+	                    name {
+		                    first
+		                    last
+		                    full
+		                    native
+	                    }
+	                    language
+	                    descriptionMd: description(asHtml: false)
+	                    descriptionHtml: description(asHtml: true)
+	                    siteUrl
+	                    staffMedia {
+		                    nodes {
+			                    id
+		                    }
+	                    }
+	                    "
+                        + CharactersForStaff(1) + 
+                        @"
+	                    characterMedia {
+		                    nodes {
+			                    id
+		                    }
+	                    }
+	                    image {
+		                    large
+		                    medium
+	                    }
+	                    favourites
+	                    modNotes
+                    }";
+        }
+
+        #endregion
+
+        #region Query Parts
+
+        /// <summary>
+        /// Get query part that can be used to retrieve <see cref="CharacterConnection"/> for <see cref="Staff"/>
+        /// </summary>
+        /// <param name="page">The page to retrievve</param>
+        /// <returns>Query to retrieve staff characters</returns>
+        private static string CharactersForStaff(int page)
+        {
+            return @"characters (page: " + page + @") {
+                            edges{
+                                node{
+                                    id,
+                                    name {
+                                        first
+                                        last
+                                }
+                                media {
+                                    nodes{
+                                        id
+                                        type              
+                                    }
+                                }
+                            }
+                        }
+	                }";
+        }
+
+        /// <summary>
+        /// Get query part that can be used to retrieve <see cref="Character"/> media entries
+        /// </summary>
+        /// <param name="page">The page to retrieve</param>
+        /// <returns>Query to retrieve character media</returns>
+        private static string CharacterMediaQuery(int page)
+        {
+            return @"media (page: " + page + @") { 
+		                    nodes {
+			                    id
+                                type
+		                    }
+                            edges {
+                                node {
+                                    id
+                                }
+                                characterRole
+                            }
+	                    }";
+        }
+
+        /// <summary>
+        /// Retrieve the query for characters that form part of the <see cref="Media"/> query.
+        /// This can also be used to retrieve characters for shows that have more than the page limit of 25
+        /// </summary>
+        /// <param name="page">The page to retrieve</param>
+        /// <returns>Query to retrieve characters</returns>
+        private static string CharacterQuery(int page)
+        {
+            return @"characters (page: " + page + @") {
+                      edges {
+                        node {
+                          id
+                        }
+                        role
+                        voiceActors {
+                          id
+                        }
+                      }
+                    }";
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
This request adds paging to some of the data collections. 
In cases such as characters for a Media entry only 25 entries are retrieved by default and the rest has to be requested as separate pages. I've added paging to all the collections that I use that require it. To make paging easier and cleaner I've moved the GraphQL queries to a new class and separated the parts that need to be paged out. That way the first 25 entries are retrieved along with the Media (or other types) and the rest are requested if required returning only the page data that is needed.

I have also expanded one or two of the Media/Character/Staff entries to include additional data that I use to filter entries (for example I don't make use of Manga, my app only deals with anime so Character media entries now includes the media type).

Finally I added code documentation to all of the methods in the Client.cs class.