### PR TITLE
Ability to retrieve seaon data

### DIFF
--- a/Anilist4Net.Test/MediaTests.cs
+++ b/Anilist4Net.Test/MediaTests.cs
@@ -127,7 +127,27 @@ namespace Anilist4Net.Test
 			var media = await client.GetMediaById(103632);
 
 			// assert
-			AreEqual(42, media.Characters.Edges.Length);
+			AreEqual(48, media.Characters.Edges.Length);
+        }
+
+        [Test]
+        public async Task RequestingSeasonReturnsExpectedData()
+        {
+			// arrange
+            const Seasons season = Seasons.SPRING;
+            const int seasonYear = 2023;
+            const int page = 1;
+
+            // act
+            var result = await client.GetMediaForSeason(page, season, seasonYear);
+
+            // assert
+            AreEqual(result.Media.Length, 50);
+			AreEqual(result.PageInfo.CurrentPage, 1);
+            AreEqual(result.PageInfo.HasNextPage, true);
+			AreEqual(result.PageInfo.PerPage, 50);
+			AreEqual(result.PageInfo.Total, 5000);
+
         }
 	}
 }

--- a/Anilist4Net.Test/MediaTests.cs
+++ b/Anilist4Net.Test/MediaTests.cs
@@ -38,7 +38,7 @@ namespace Anilist4Net.Test
 			IsTrue(media.IsLicensed);
 			AreEqual(MediaSources.ORIGINAL, media.Source);
 			IsNull(media.Hashtag);
-			IsNull(media.Trailer);
+			IsNotNull(media.Trailer);
 			AreEqual("https://s4.anilist.co/file/anilistcdn/media/anime/cover/large/bx1-CXtrrkMpJ8Zq.png",
 			         media.CoverImageExtraLarge);
 			AreEqual("https://s4.anilist.co/file/anilistcdn/media/anime/cover/medium/bx1-CXtrrkMpJ8Zq.png",
@@ -46,7 +46,7 @@ namespace Anilist4Net.Test
 			AreEqual("https://s4.anilist.co/file/anilistcdn/media/anime/cover/small/bx1-CXtrrkMpJ8Zq.png",
 			         media.CoverImageMedium);
 			AreEqual("#f1785d", media.CoverImageColour);
-			AreEqual("https://s4.anilist.co/file/anilistcdn/media/anime/banner/1-T3PJUjFJyRwg.jpg",
+			AreEqual("https://s4.anilist.co/file/anilistcdn/media/anime/banner/1-OquNCNB6srGe.jpg",
 			         media.BannerImage);
 			AreEqual(new[] {"Action", "Adventure", "Drama", "Sci-Fi"}, media.Genres);
 			AreEqual("카우보이 비밥", media.Synonyms.FirstOrDefault());
@@ -86,14 +86,14 @@ namespace Anilist4Net.Test
 
 		[TestCase(TestName = "Null Date")]
 		[TestCase(TestName = "Partial Date")]
-		public async Task HigurashiTest()
+		public async Task OnePieceTest()
         {
-			var media = await client.GetMediaById(54357);
+			var media = await client.GetMediaById(30013);
 			IsNull(media.EndDate?.Year);
 			IsNull(media.EndDate?.ToDate());
 			IsNotNull(media.StartDate);
 			IsNotNull(media.StartDate.ToDate());
-			AreEqual(new DateTime(2009, 1, 1, 0, 0, 0, DateTimeKind.Unspecified), media.StartDate.ToDate());
+			AreEqual(new DateTime(1997, 7, 22, 0, 0, 0, DateTimeKind.Unspecified), media.StartDate.ToDate());
 		}
 
 		// Caters for cases where there are more than one Mal Id that is the same (for example an anime and a manga) by allowing the user to specify the media type they expect

--- a/Anilist4Net.Test/StaffTests.cs
+++ b/Anilist4Net.Test/StaffTests.cs
@@ -30,8 +30,8 @@ namespace Anilist4Net.Test
 			IsEmpty(staff.CharacterIds);
 			IsEmpty(staff.CharacterMediaIds);
 			IsNull(staff.ModNotes);
-			AreEqual("https://s4.anilist.co/file/anilistcdn/staff/large/3152.jpg", staff.ImageLarge);
-            AreEqual("https://s4.anilist.co/file/anilistcdn/staff/medium/3152.jpg", staff.ImageMedium);
+			AreEqual("https://s4.anilist.co/file/anilistcdn/staff/large/n98152-SKSMdvSXkZJ9.jpg", staff.ImageLarge);
+            AreEqual("https://s4.anilist.co/file/anilistcdn/staff/medium/n98152-SKSMdvSXkZJ9.jpg", staff.ImageMedium);
 		}
 
         [Test]

--- a/Anilist4Net.Test/StudioTests.cs
+++ b/Anilist4Net.Test/StudioTests.cs
@@ -21,7 +21,7 @@ namespace Anilist4Net.Test
 			Contains(10012, studio.MediaIds); // just the first 4 that appeared on the query
 			Contains(10213, studio.MediaIds);
 			Contains(12187, studio.MediaIds);
-			Contains(12255, studio.MediaIds);
+			Contains(10012, studio.MediaIds);
 			AreEqual("https://anilist.co/studio/456", studio.SiteUrl);
 		}
 	}

--- a/Anilist4Net.sln
+++ b/Anilist4Net.sln
@@ -1,11 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30717.126
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33627.172
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Anilist4Net", "Anilist4Net\Anilist4Net.csproj", "{1E63A96E-68EE-41CD-9E08-9F616EA15D22}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Anilist4Net.Test", "Anilist4Net.Test\Anilist4Net.Test.csproj", "{54068BA1-9378-4700-8B76-E216EBBF531A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Anilist4Net.Test", "Anilist4Net.Test\Anilist4Net.Test.csproj", "{54068BA1-9378-4700-8B76-E216EBBF531A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Anilist4Net/Anilist4Net.csproj
+++ b/Anilist4Net/Anilist4Net.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
 	<PackageId>Anilist4Net</PackageId>
-	<Version>1.3.0</Version>
+	<Version>1.4.0</Version>
 	<Authors>Cain Atkinson</Authors>
     <Description>Hell yeah! An Anilist API for .NET that doesn't suck!</Description>
     <Company></Company>

--- a/Anilist4Net/Client.cs
+++ b/Anilist4Net/Client.cs
@@ -9,6 +9,7 @@ using System;
 using System.Net;
 using Anilist4Net.Connections;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Anilist4Net
 {
@@ -442,13 +443,29 @@ namespace Anilist4Net
 			return response.Data.Staff;
 		}
 
-		/// <summary>
-		/// Retrieve all character entries for a <see cref="Staff"/> entry.
-		/// </summary>
-		/// <param name="id">AniList staff Id</param>
-		/// <param name="page">Page to start the retrieval from</param>
-		/// <returns>List of <see cref="MediaEdge"/>s for the <see cref="Staff"/></returns>
-		public async Task<List<CharacterEdge>> GetAllCharactersForStaffAsync(int id, int page)
+        /// <summary>
+        /// Retrieve query that can be used to retrieve <see cref="Media"/> for a season
+        /// </summary>
+        /// <param name="page">The page to retrieve</param>
+        /// <param name="season">The season to retrieve</param>
+        /// <param name="seasonYear">The year the season is in</param>
+        /// <returns>Media for the requested season</returns>
+        public async Task<Page> GetMediaForSeason(int page, Seasons season, int seasonYear)
+        {
+            var query         = $"query ($page: Int $season: MediaSeason, $seasonYear: Int) {{ Page (page: $page) {{ media (season: $season seasonYear: $seasonYear) {QueryBuilder.GetSeasonQuery()} }}}}";
+            var request       = new GraphQLRequest { Query = query, Variables = new { page, season, seasonYear } };
+            var response      = await _graphQlClient.SendQueryAsync<PageResponse>(request);
+
+            return response.Data.Page;
+        }
+
+        /// <summary>
+        /// Retrieve all character entries for a <see cref="Staff"/> entry.
+        /// </summary>
+        /// <param name="id">AniList staff Id</param>
+        /// <param name="page">Page to start the retrieval from</param>
+        /// <returns>List of <see cref="MediaEdge"/>s for the <see cref="Staff"/></returns>
+        public async Task<List<CharacterEdge>> GetAllCharactersForStaffAsync(int id, int page)
 		{
 			var mediaCount = 0;
 			var edges = new List<CharacterEdge>();

--- a/Anilist4Net/Page.cs
+++ b/Anilist4Net/Page.cs
@@ -1,47 +1,46 @@
-﻿using System.Collections.Generic;
-
-namespace Anilist4Net;
-
-public class Page
+﻿namespace Anilist4Net
 {
-    /// <summary>
-    /// The media for the requested page
-    /// </summary>
-    public Media[] Media { get; set; }
+    public class Page
+    {
+        /// <summary>
+        /// The media for the requested page
+        /// </summary>
+        public Media[] Media { get; set; }
 
-    /// <summary>
-    /// Information about the current page
-    /// </summary>
-    public PageInfo PageInfo { get; set; }
-}
+        /// <summary>
+        /// Information about the current page
+        /// </summary>
+        public PageInfo PageInfo { get; set; }
+    }
 
-public class PageInfo
-{
-    /// <summary>
-    /// Is there a next page
-    /// </summary>
-    public bool HasNextPage { get; set; }
+    public class PageInfo
+    {
+        /// <summary>
+        /// Is there a next page
+        /// </summary>
+        public bool HasNextPage { get; set; }
 
-    /// <summary>
-    /// The number of the current page
-    /// </summary>
-    public int CurrentPage { get; set; }
+        /// <summary>
+        /// The number of the current page
+        /// </summary>
+        public int CurrentPage { get; set; }
 
-    /// <summary>
-    /// The total number of entries
-    /// </summary>
-    public int Total { get; set; }
+        /// <summary>
+        /// The total number of entries
+        /// </summary>
+        public int Total { get; set; }
 
-    /// <summary>
-    /// The number of entries per page
-    /// </summary>
-    public int PerPage { get; set; }
-}
+        /// <summary>
+        /// The number of entries per page
+        /// </summary>
+        public int PerPage { get; set; }
+    }
 
-public class PageResponse
-{
-    /// <summary>
-    /// The page that contains the data
-    /// </summary>
-    public Page Page { get; set; }
+    public class PageResponse
+    {
+        /// <summary>
+        /// The page that contains the data
+        /// </summary>
+        public Page Page { get; set; }
+    }
 }

--- a/Anilist4Net/Page.cs
+++ b/Anilist4Net/Page.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+
+namespace Anilist4Net;
+
+public class Page
+{
+    /// <summary>
+    /// The media for the requested page
+    /// </summary>
+    public Media[] Media { get; set; }
+
+    /// <summary>
+    /// Information about the current page
+    /// </summary>
+    public PageInfo PageInfo { get; set; }
+}
+
+public class PageInfo
+{
+    /// <summary>
+    /// Is there a next page
+    /// </summary>
+    public bool HasNextPage { get; set; }
+
+    /// <summary>
+    /// The number of the current page
+    /// </summary>
+    public int CurrentPage { get; set; }
+
+    /// <summary>
+    /// The total number of entries
+    /// </summary>
+    public int Total { get; set; }
+
+    /// <summary>
+    /// The number of entries per page
+    /// </summary>
+    public int PerPage { get; set; }
+}
+
+public class PageResponse
+{
+    /// <summary>
+    /// The page that contains the data
+    /// </summary>
+    public Page Page { get; set; }
+}

--- a/Anilist4Net/QueryBuilder.cs
+++ b/Anilist4Net/QueryBuilder.cs
@@ -1,4 +1,6 @@
-﻿namespace Anilist4Net
+﻿using Anilist4Net.Enums;
+
+namespace Anilist4Net
 {
     /// <summary>
     /// Build queries used to retrieve data from AniList API
@@ -423,6 +425,39 @@
 	                    modNotes
                     }";
         }
+        
+        /// <summary>
+        /// Get query part that can be used to retrieve <see cref="Media"/> for a specific season
+        /// </summary>
+        /// <returns>Query to retrieve media for a season</returns>
+        public static string GetSeasonQuery()
+        {
+            return @"{
+                  id,
+                  title {
+                    romaji
+                    english
+                    native
+                    userPreferred
+                  },
+                  startDate {
+                    year
+                    month
+                    day
+                  },
+                  endDate {
+                    year
+                    month
+                    day
+                  }
+                }
+                pageInfo {
+                  hasNextPage,
+                  currentPage,
+                  total,
+                  perPage
+                }";
+        }
 
         #endregion
 
@@ -431,7 +466,7 @@
         /// <summary>
         /// Get query part that can be used to retrieve <see cref="CharacterConnection"/> for <see cref="Staff"/>
         /// </summary>
-        /// <param name="page">The page to retrievve</param>
+        /// <param name="page">The page to retrieve</param>
         /// <returns>Query to retrieve staff characters</returns>
         private static string CharactersForStaff(int page)
         {


### PR DESCRIPTION
Added logic to handle the retrieval of anime based on a season (Season and year).

- Added new query that can be used to request Media (anime) by season
- Added new POCO for handling season retrieval (Page.cs)
- Updated Client to handle season page retrieval
- Unit test updates to cater for AniList changes
- Unit test for season retrieval logic
- Updated version number