### PR TITLE
Retrieval fix

### DIFF
--- a/Anilist4Net/Media.cs
+++ b/Anilist4Net/Media.cs
@@ -42,7 +42,7 @@ namespace Anilist4Net
 		/// <summary>
 		///     The format of the media
 		/// </summary>
-		public MediaFormats Format { get; set; }
+		public MediaFormats? Format { get; set; }
 
 		/// <summary>
 		///     The status of the media (airing, finished, etc)


### PR DESCRIPTION
- Fixed an issue where shows without a MediaFormat would cause an exception to be thrown

I did not include a unit test as the test would break the moment a show's format gets set.
Issue can be replicated by trying to retrieve 163571 with MediaFormat not being nullable.