### PR TITLE
Rate limit return

### DIFF
--- a/Anilist4Net.Test/MediaTests.cs
+++ b/Anilist4Net.Test/MediaTests.cs
@@ -147,7 +147,18 @@ namespace Anilist4Net.Test
             AreEqual(result.PageInfo.HasNextPage, true);
 			AreEqual(result.PageInfo.PerPage, 50);
 			AreEqual(result.PageInfo.Total, 5000);
+        }
 
+		[TestCase(114411)]
+		[TestCase(775)]
+		public async Task RateLimitReturned(int animeId)
+		{
+            // arrange
+            // act
+            var media = await client.GetMediaByIdWithRateLimit(animeId);
+			
+            // assert
+            LessOrEqual(media.rateLimitLeft, 90);
         }
 
         [Test]

--- a/Anilist4Net/Client.RateLimit.cs
+++ b/Anilist4Net/Client.RateLimit.cs
@@ -246,6 +246,7 @@ public partial class Client
         GraphQLResponse<MediaResponse>? response = null;
         do
         {
+            var timeoutHit = false;
             try
             {
                 var query = $"query ($id: Int) {{ Media (id: $id) {QueryBuilder.GetCharactersForMediaQuery(page)} }}";
@@ -255,10 +256,23 @@ public partial class Client
                 characters.AddRange(response.Data.Media.Characters.Edges);
                 page++;
             }
+            catch (GraphQLHttpRequestException exception)
+            {
+                if (exception.GetRemainingLimit() == 0)
+                {
+                    timeoutHit = true;
+                }
+            }
             catch (Exception)
             {
                 // What to do here? We don't really mind as we can just keep trying until the end
             }
+
+            if (ObeyRateLimit && (timeoutHit || response.GetRemainingLimit() <= RateLimitTolerance))
+            {
+                await Task.Delay(RateLimitTimeout);
+            }
+
         } while (characterCount >= 25);
 
         return (characters, response.GetRemainingLimit());
@@ -344,6 +358,7 @@ public partial class Client
         GraphQLResponse<CharacterResponse>? response = null;
         do
         {
+            var timeoutHit = false;
             try
             {
                 var query = $"query ($id: Int) {{ Character (id: $id) {QueryBuilder.GetCharacterMediaQuery(page)} }}";
@@ -355,9 +370,21 @@ public partial class Client
 
                 page++;
             }
+            catch (GraphQLHttpRequestException exception)
+            {
+                if (exception.GetRemainingLimit() == 0)
+                {
+                    timeoutHit = true;
+                }
+            }
             catch (Exception)
             {
                 // What to do here? We don't really mind as we can just keep trying until the end
+            }
+
+            if (ObeyRateLimit && (timeoutHit || response.GetRemainingLimit() <= RateLimitTolerance))
+            {
+                await Task.Delay(RateLimitTimeout);
             }
         } while (mediaCount >= 25);
 
@@ -479,6 +506,7 @@ public partial class Client
         GraphQLResponse<StaffResponse>? response = null;
         do
         {
+            var timeoutHit = false;
             try
             {
                 var query = $"query ($id: Int) {{ Staff (id: $id) {QueryBuilder.GetStaffCharactersQuery(page)} }}";
@@ -489,9 +517,21 @@ public partial class Client
 
                 page++;
             }
+            catch (GraphQLHttpRequestException exception)
+            {
+                if (exception.GetRemainingLimit() == 0)
+                {
+                    timeoutHit = true;
+                }
+            }
             catch (Exception)
             {
                 // What to do here? We don't really mind as we can just keep trying until the end
+            }
+
+            if (ObeyRateLimit && (timeoutHit || response.GetRemainingLimit() <= RateLimitTolerance))
+            {
+                await Task.Delay(RateLimitTimeout);
             }
         } while (mediaCount >= 25);
 

--- a/Anilist4Net/Client.RateLimit.cs
+++ b/Anilist4Net/Client.RateLimit.cs
@@ -1,0 +1,500 @@
+﻿#nullable enable
+using Anilist4Net.Connections;
+using Anilist4Net.Enums;
+using GraphQL;
+using GraphQL.Client.Http;
+using System.Collections.Generic;
+using System;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace Anilist4Net;
+
+/// <summary>
+/// Client used to handle retrieval of data from AniList Graph API
+/// </summary>
+public partial class Client
+{
+    /// <summary>
+    /// Retrieve a <see cref="User"/> by their username
+    /// </summary>
+    /// <param name="username">Username of the user to retrieve</param>
+    /// <returns>User data and remaining rate limit</returns>
+    public async Task<(User user, int rateLimit)> GetUserByNameWithRateLimit(string username)
+    {
+        var query = $"query ($username: String) {{ User (name: $username) {QueryBuilder.GetUserQuery()} }}";
+        var request = new GraphQLRequest { Query = query, Variables = new { username } };
+        var response = await _graphQlClient.SendQueryAsync<UserResponse>(request);
+
+        return (response.Data.User, response.GetRemainingLimit());
+    }
+
+    /// <summary>
+    /// Retrieve a <see cref="User"/> by their AniList Id
+    /// </summary>
+    /// <param name="id">user's AniList Id</param>
+    /// <returns>User data and remaining rate limit</returns>
+    public async Task<(User user, int rateLimit)> GetUserByIdWithRateLimit(int id)
+    {
+        var query = $"query ($id: Int) {{ User (id: $id) {QueryBuilder.GetUserQuery()} }}";
+        var request = new GraphQLRequest { Query = query, Variables = new { id } };
+        var response = await _graphQlClient.SendQueryAsync<UserResponse>(request);
+
+        return (response.Data.User, response.GetRemainingLimit());
+    }
+
+    /// <summary>
+    /// Retrieve a <see cref="Media"/> entry by its AniList Id
+    /// </summary>
+    /// <param name="id">AniList media Id</param>
+    /// <returns>Media instance if it exists, otherwise null</returns>
+    public async Task<(Media? media, int rateLimitLeft)> GetMediaByIdWithRateLimit(int id)
+    {
+        var query = $"query ($id: Int) {{ Media (id: $id) {QueryBuilder.GetMediaQuery()} }}";
+        var request = new GraphQLRequest { Query = query, Variables = new { id } };
+        GraphQLResponse<MediaResponse> response = null!;
+        try
+        {
+            response = await _graphQlClient.SendQueryAsync<MediaResponse>(request);
+            var characterCount = response.Data.Media.Characters.Edges.Length;
+            if (characterCount >= 25)
+            {
+                var additionalCharacters = await GetAllCharactersAsync(id, 2);
+                additionalCharacters.AddRange(response.Data.Media.Characters.Edges);
+                response.Data.Media.Characters.Edges = additionalCharacters.ToArray();
+            }
+        }
+        catch (GraphQLHttpRequestException e)
+        {
+            if (e.StatusCode == HttpStatusCode.NotFound)
+                return (null, e.GetRemainingLimit()); // media did not exist
+        }
+
+        return (response?.Data.Media, response.GetRemainingLimit());
+    }
+
+    /// <summary>
+    /// Retrieve a <see cref="Media"/> entry by its MyAnimeList Id.
+    /// <remarks>
+    ///		If there is both a matching anime and manga entry for the provided MAL Id it is uncertain which entry will be returned.
+    ///		To better control the response rather use the <see cref="GetMediaByMalId(int, MediaTypes)"/> method.
+    /// </remarks>
+    /// </summary>
+    /// <param name="id">MAL Id to retrieve entry for</param>
+    /// <returns>Media instance if one could be found, otherwise null</returns>
+    public async Task<(Media? media, int rateLimit)> GetMediaByMalIdWithRateLimit(int id)
+    {
+        var query = $"query ($id: Int) {{ Media (idMal: $id) {QueryBuilder.GetMediaQuery()} }}";
+        var request = new GraphQLRequest { Query = query, Variables = new { id } };
+        GraphQLResponse<MediaResponse> response = null!;
+        try
+        {
+            response = await _graphQlClient.SendQueryAsync<MediaResponse>(request);
+            var characterCount = response.Data.Media.Characters.Edges.Length;
+            if (characterCount >= 25)
+            {
+                // Swap to the AniList Id rather than using the Mal Id
+                var additionalCharacters = await GetAllCharactersAsync(response.Data.Media.Id, 2);
+                additionalCharacters.AddRange(response.Data.Media.Characters.Edges);
+                response.Data.Media.Characters.Edges = additionalCharacters.ToArray();
+            }
+        }
+        catch (GraphQLHttpRequestException e)
+        {
+            if (e.StatusCode == HttpStatusCode.NotFound)
+                return (null, e.GetRemainingLimit()); // media did not exist
+        }
+
+        return (response?.Data.Media, response.GetRemainingLimit());
+    }
+
+    /// <summary>
+    /// Retrieve a <see cref="Media"/> entry by its MyAnimeList Id and its AniList type
+    /// </summary>
+    /// <param name="id">MAL Id to retrieve entry for</param>
+    /// <param name="mediaType">The type of media to retrieve</param>
+    /// <returns>Media instance if one could be found, otherwise null</returns>
+    public async Task<(Media? media, int rateLimit)> GetMediaByMalIdWithRateLimit(int id, MediaTypes mediaType)
+    {
+        var query = $"query ($id: Int) {{ Media (idMal: $id type: {mediaType}) {QueryBuilder.GetMediaQuery()} }}";
+        var request = new GraphQLRequest { Query = query, Variables = new { id } };
+        GraphQLResponse<MediaResponse> response = null!;
+        try
+        {
+            response = await _graphQlClient.SendQueryAsync<MediaResponse>(request);
+            var characterCount = response.Data.Media.Characters.Edges.Length;
+            if (characterCount >= 25)
+            {
+                var additionalCharacters = await GetAllCharactersAsync(id, 2);
+                additionalCharacters.AddRange(response.Data.Media.Characters.Edges);
+                response.Data.Media.Characters.Edges = additionalCharacters.ToArray();
+            }
+        }
+        catch (GraphQLHttpRequestException e)
+        {
+            if (e.StatusCode == HttpStatusCode.NotFound)
+                return (null, e.GetRemainingLimit()); // media did not exist
+        }
+
+        return (response?.Data.Media, response.GetRemainingLimit());
+    }
+
+    /// <summary>
+    /// Search for a <see cref="Media"/> entry by its title
+    /// </summary>
+    /// <param name="search">Search query</param>
+    /// <returns>Media instance if one could be found, otherwise null</returns>
+    public async Task<(Media? media, int rateLimit)> GetMediaBySearchWithRateLimit(string search)
+    {
+        var query = $"query ($search: String) {{ Media (search: $search) {QueryBuilder.GetMediaQuery()} }}";
+        var request = new GraphQLRequest { Query = query, Variables = new { search } };
+        GraphQLResponse<MediaResponse> response = null!;
+        try
+        {
+            response = await _graphQlClient.SendQueryAsync<MediaResponse>(request);
+            var characterCount = response.Data.Media.Characters.Edges.Length;
+            if (characterCount >= 25)
+            {
+                var additionalCharacters = await GetAllCharactersAsync(response.Data.Media.Id, 2);
+                additionalCharacters.AddRange(response.Data.Media.Characters.Edges);
+                response.Data.Media.Characters.Edges = additionalCharacters.ToArray();
+            }
+        }
+        catch (GraphQLHttpRequestException e)
+        {
+            if (e.StatusCode == HttpStatusCode.NotFound)
+                return (null, e.GetRemainingLimit()); // media did not exist
+        }
+
+        return (response?.Data.Media, response.GetRemainingLimit());
+    }
+
+    /// <summary>
+    /// Search for a <see cref="Media"/> entry by its title
+    /// </summary>
+    /// <param name="search">Search query</param>
+    /// <param name="type">The type of media to search for</param>
+    /// <returns>Media instance if one could be found, otherwise null</returns>
+    public async Task<(Media? media, int rateLimit)> GetMediaBySearchWithRateLimit(string search, MediaTypes type)
+    {
+        var query = $"query ($search: String $type: MediaType) {{ Media (search: $search type: $type) {QueryBuilder.GetMediaQuery()} }}";
+        var request = new GraphQLRequest { Query = query, Variables = new { search, type } };
+        GraphQLResponse<MediaResponse> response = null!;
+        try
+        {
+            response = await _graphQlClient.SendQueryAsync<MediaResponse>(request);
+            var characterCount = response.Data.Media.Characters.Edges.Length;
+            if (characterCount >= 25)
+            {
+                var additionalCharacters = await GetAllCharactersAsync(response.Data.Media.Id, 2);
+                additionalCharacters.AddRange(response.Data.Media.Characters.Edges);
+                response.Data.Media.Characters.Edges = additionalCharacters.ToArray();
+            }
+        }
+        catch (GraphQLHttpRequestException e)
+        {
+            if (e.StatusCode == HttpStatusCode.NotFound)
+                return (null, e.GetRemainingLimit()); // media did not exist
+        }
+
+        return (response?.Data.Media, response.GetRemainingLimit());
+    }
+
+    /// <summary>
+    /// Search for <see cref="Media"/> entries by its title
+    /// </summary>
+    /// <param name="search">Search query</param>
+    /// <param name="page">The page to search on</param>
+    /// <param name="perPage">The number of entries per page</param>
+    /// <returns>A paginated list of Media instances if found</returns>
+    public async Task<(Page page, int rateLimit)> GetMediaBySearchWithRateLimit(string search, int page, int perPage)
+    {
+        var query = $"query ($search: String, $page: Int, $perPage: Int) {{ Page(page: $page, perPage: $perPage) {{ {QueryBuilder.GetPageInfoQuery()} media (search: $search) {QueryBuilder.GetMediaQuery()} }} }}";
+        var request = new GraphQLRequest { Query = query, Variables = new { search, page, perPage } };
+        var response = await _graphQlClient.SendQueryAsync<PageResponse>(request);
+
+        return (response.Data.Page, response.GetRemainingLimit());
+    }
+
+    /// <summary>
+    /// Search for <see cref="Media"/> entries by its title
+    /// </summary>
+    /// <param name="search">Search query</param>
+    /// <param name="type">The type of media to search for</param>
+    /// <param name="page">The page to search on</param>
+    /// <param name="perPage">The number of entries per page</param>
+    /// <returns>A paginated list of Media instances if found</returns>
+    public async Task<(Page? page, int rateLimit)> GetMediaBySearchWithRateLimit(string search, MediaTypes type, int page, int perPage)
+    {
+        var query = $"query ($search: String, $type: MediaType, $page: Int, $perPage: Int) {{ Page(page: $page, perPage: $perPage) {{ {QueryBuilder.GetPageInfoQuery()} media (search: $search, type: $type) {QueryBuilder.GetMediaQuery()} }} }}";
+        var request = new GraphQLRequest { Query = query, Variables = new { search, type, page, perPage } };
+        var response = await _graphQlClient.SendQueryAsync<PageResponse>(request);
+
+        return (response.Data.Page, response.GetRemainingLimit());
+    }
+
+    /// <summary>
+    /// Retrieve all characters for a <see cref="Media"/> entry.
+    /// </summary>
+    /// <param name="id">AniList media Id</param>
+    /// <param name="page">Page to start the retrieval from</param>
+    /// <returns>List of <see cref="CharacterEdge"/>s for the Media</returns>
+    public async Task<(List<CharacterEdge> characters, int rateLimit)> GetAllCharactersAsyncWithRateLimit(int id, int page)
+    {
+        var characterCount = 0;
+        var characters = new List<CharacterEdge>();
+        GraphQLResponse<MediaResponse>? response = null;
+        do
+        {
+            try
+            {
+                var query = $"query ($id: Int) {{ Media (id: $id) {QueryBuilder.GetCharactersForMediaQuery(page)} }}";
+                var request = new GraphQLRequest { Query = query, Variables = new { id } };
+                response = await _graphQlClient.SendQueryAsync<MediaResponse>(request);
+                characterCount = response.Data.Media.Characters.Edges.Length;
+                characters.AddRange(response.Data.Media.Characters.Edges);
+                page++;
+            }
+            catch (Exception)
+            {
+                // What to do here? We don't really mind as we can just keep trying until the end
+            }
+        } while (characterCount >= 25);
+
+        return (characters, response.GetRemainingLimit());
+    }
+
+    /// <summary>
+    /// Retrieve a <see cref="Review"/> by its AniList Id
+    /// </summary>
+    /// <param name="id">Id of the review to retrieve</param>
+    /// <returns>Review for the requested Id</returns>
+    public async Task<(Review review, int rateLimit)> GetReviewByIdWithRateLimit(int id)
+    {
+        var query = $"query ($id: Int) {{ Review (id: $id) {QueryBuilder.GetReviewQuery()} }}";
+        var request = new GraphQLRequest { Query = query, Variables = new { id } };
+        var response = await _graphQlClient.SendQueryAsync<ReviewResponse>(request);
+
+        return (response.Data.Review, response.GetRemainingLimit());
+    }
+
+    /// <summary>
+    /// Retrieve an <see cref="AiringSchedule"/> entry by its AniList Id
+    /// </summary>
+    /// <param name="id">AniList Id of the schedule entry to retrieve</param>
+    /// <returns>AiringSchedule entry</returns>
+    public async Task<(AiringSchedule schedule, int rateLimit)> GetAiringScheduleByIdWithRateLimit(int id)
+    {
+        var query = $"query ($id: Int) {{ AiringSchedule (id: $id) {QueryBuilder.GetAiringScheduleQuery()} }}";
+        var request = new GraphQLRequest { Query = query, Variables = new { id } };
+        var response = await _graphQlClient.SendQueryAsync<AiringScheduleResponse>(request);
+
+        return (response.Data.AiringSchedule, response.GetRemainingLimit());
+    }
+
+    /// <summary>
+    /// Retrieve a <see cref="Recommendation"/> entry by its AniList Id
+    /// </summary>
+    /// <param name="id">AniList Id of the recommendation to retrieve</param>
+    /// <returns>Recommendation entry</returns>
+    public async Task<(Recommendation recommendation, int rateLimit)> GetRecommendationByIdWithRateLimit(int id)
+    {
+        var query = $"query ($id: Int) {{ Recommendation (id: $id) {QueryBuilder.GetRecommendationQuery()} }}";
+        var request = new GraphQLRequest { Query = query, Variables = new { id } };
+        var response = await _graphQlClient.SendQueryAsync<RecommendationResponse>(request);
+
+        return (response.Data.Recommendation, response.GetRemainingLimit());
+    }
+
+    /// <summary>
+    /// Retrieve a <see cref="Character"/> entry by its AniList Id
+    /// </summary>
+    /// <param name="id">AniList Id of the character to retrieve</param>
+    /// <returns>Character entry</returns>
+    public async Task<(Character character, int rateLimit)> GetCharacterByIdWithRateLimit(int id)
+    {
+        var query = $"query ($id: Int) {{ Character (id: $id) {QueryBuilder.GetCharacterQuery()} }}";
+        var request = new GraphQLRequest { Query = query, Variables = new { id } };
+        var response = await _graphQlClient.SendQueryAsync<CharacterResponse>(request);
+
+        var mediaCount = response.Data.Character.Media.Edges.Length;
+        if (mediaCount >= 25)
+        {
+            var additionalMedia = await GetAllMediaEntriesForCharacter(id, 2);
+            additionalMedia.edges.AddRange(response.Data.Character.Media.Edges);
+            additionalMedia.nodes.AddRange(response.Data.Character.Media.Nodes);
+            response.Data.Character.Media.Edges = additionalMedia.edges.ToArray();
+            response.Data.Character.Media.Nodes = additionalMedia.nodes.ToArray();
+        }
+
+        return (response.Data.Character, response.GetRemainingLimit());
+    }
+
+    /// <summary>
+    /// Retrieve all media entries for a <see cref="Character"/> entry.
+    /// </summary>
+    /// <param name="id">AniList character Id</param>
+    /// <param name="page">Page to start the retrieval from</param>
+    /// <returns>Tuple containing a list of <see cref="MediaEdge"/>s and <see cref="MediaNodePlaceholder"/>s for the <see cref="Character"/></returns>
+    public async Task<(List<CharacterEdge> edges, List<MediaNodePlaceholder> nodes, int rateLimit)> GetAllMediaEntriesForCharacterWithRateLimit(int id, int page)
+    {
+        var mediaCount = 0;
+        var edges = new List<CharacterEdge>();
+        var nodes = new List<MediaNodePlaceholder>();
+        GraphQLResponse<CharacterResponse>? response = null;
+        do
+        {
+            try
+            {
+                var query = $"query ($id: Int) {{ Character (id: $id) {QueryBuilder.GetCharacterMediaQuery(page)} }}";
+                var request = new GraphQLRequest { Query = query, Variables = new { id } };
+                response = await _graphQlClient.SendQueryAsync<CharacterResponse>(request);
+                mediaCount = response.Data.Character.Media.Edges.Length;
+                edges.AddRange(response.Data.Character.Media.Edges);
+                nodes.AddRange(response.Data.Character.Media.Nodes);
+
+                page++;
+            }
+            catch (Exception)
+            {
+                // What to do here? We don't really mind as we can just keep trying until the end
+            }
+        } while (mediaCount >= 25);
+
+        return (edges, nodes, response.GetRemainingLimit());
+    }
+
+    /// <summary>
+    /// Search for a <see cref="Character"/>
+    /// </summary>
+    /// <param name="search">Search query</param>
+    /// <returns>Character matching the query</returns>
+    public async Task<(Character character, int rateLimit)> GetCharacterBySearchWithRateLimit(string search)
+    {
+        var query = $"query ($search: String) {{ Character (search: $search) {QueryBuilder.GetCharacterQuery()} }}";
+        var request = new GraphQLRequest { Query = query, Variables = new { search } };
+        var response = await _graphQlClient.SendQueryAsync<CharacterResponse>(request);
+
+        return (response.Data.Character, response.GetRemainingLimit());
+    }
+
+    /// <summary>
+    /// Retrieve a <see cref="Studio"/> by its AniList Id
+    /// </summary>
+    /// <param name="id">Studio Id</param>
+    /// <returns>Studio for the Id</returns>
+    public async Task<(Studio studio, int rateLimit)> GetStudioByIdWithRateLimit(int id)
+    {
+        var query = $"query ($id: Int) {{ Studio (id: $id) {QueryBuilder.GetStudioQuery()} }}";
+        var request = new GraphQLRequest { Query = query, Variables = new { id } };
+        var response = await _graphQlClient.SendQueryAsync<StudioResponse>(request);
+
+        return (response.Data.Studio, response.GetRemainingLimit());
+    }
+
+    /// <summary>
+    /// Search for a <see cref="Studio"/>
+    /// </summary>
+    /// <param name="search">Search query</param>
+    /// <returns>Studio entry matching the search query</returns>
+    public async Task<(Studio studio, int rateLimit)> GetStudioBySearchWithRateLimit(string search)
+    {
+        var query = $"query ($search: String) {{ Studio (search: $search) {QueryBuilder.GetStudioQuery()} }}";
+        var request = new GraphQLRequest { Query = query, Variables = new { search } };
+        var response = await _graphQlClient.SendQueryAsync<StudioResponse>(request);
+
+        return (response.Data.Studio, response.GetRemainingLimit());
+    }
+
+    /// <summary>
+    /// Retrieve a <see cref="Staff"/> entry from AniList
+    /// </summary>
+    /// <param name="id">Id of the staff entry to retrieve</param>
+    /// <returns>Staff entry for the Id</returns>
+    public async Task<(Staff staff, int rateLimit)> GetStaffByIdWithRateLimit(int id)
+    {
+        var query = $"query ($id: Int) {{ Staff (id: $id) {QueryBuilder.GetStaffQuery()} }}";
+        var request = new GraphQLRequest { Query = query, Variables = new { id } };
+        var response = await _graphQlClient.SendQueryAsync<StaffResponse>(request);
+
+        var characterCount = response.Data.Staff.Characters.Edges.Length;
+        if (characterCount >= 25)
+        {
+            var additionalCharacters = await GetAllCharactersForStaffAsync(id, 2);
+            additionalCharacters.AddRange(response.Data.Staff.Characters.Edges);
+            response.Data.Staff.Characters.Edges = additionalCharacters.ToArray();
+        }
+
+        return (response.Data.Staff, response.GetRemainingLimit());
+    }
+
+    /// <summary>
+    /// Search for a <see cref="Staff"/> entry
+    /// </summary>
+    /// <param name="search">Search query</param>
+    /// <returns>Staff entry matching the search</returns>
+    public async Task<(Staff staff, int rateLimit)> GetStaffBySearchWithRateLimit(string search)
+    {
+        var query = $"query ($search: String) {{ Staff (search: $search) {QueryBuilder.GetStaffQuery()} }}";
+        var request = new GraphQLRequest { Query = query, Variables = new { search } };
+        var response = await _graphQlClient.SendQueryAsync<StaffResponse>(request);
+
+        var characterCount = response.Data.Staff.Characters.Edges.Length;
+        if (characterCount >= 25)
+        {
+            var additionalCharacters = await GetAllCharactersForStaffAsync(response.Data.Staff.Id, 2);
+            additionalCharacters.AddRange(response.Data.Staff.Characters.Edges);
+            response.Data.Staff.Characters.Edges = additionalCharacters.ToArray();
+        }
+
+        return (response.Data.Staff, response.GetRemainingLimit());
+    }
+
+    /// <summary>
+    /// Retrieve query that can be used to retrieve <see cref="Media"/> for a season
+    /// </summary>
+    /// <param name="page">The page to retrieve</param>
+    /// <param name="season">The season to retrieve</param>
+    /// <param name="seasonYear">The year the season is in</param>
+    /// <returns>Media for the requested season</returns>
+    public async Task<(Page page, int rateLimit)> GetMediaForSeasonWithRateLimit(int page, Seasons season, int seasonYear)
+    {
+        var query = $"query ($page: Int $season: MediaSeason, $seasonYear: Int) {{ Page (page: $page) {{ media (season: $season seasonYear: $seasonYear) {QueryBuilder.GetSeasonQuery()} }}}}";
+        var request = new GraphQLRequest { Query = query, Variables = new { page, season, seasonYear } };
+        var response = await _graphQlClient.SendQueryAsync<PageResponse>(request);
+
+        return (response.Data.Page, response.GetRemainingLimit());
+    }
+
+    /// <summary>
+    /// Retrieve all character entries for a <see cref="Staff"/> entry.
+    /// </summary>
+    /// <param name="id">AniList staff Id</param>
+    /// <param name="page">Page to start the retrieval from</param>
+    /// <returns>List of <see cref="MediaEdge"/>s for the <see cref="Staff"/></returns>
+    public async Task<(List<CharacterEdge> characters, int rateLimit)> GetAllCharactersForStaffWithRateLimitAsync(int id, int page)
+    {
+        var mediaCount = 0;
+        var edges = new List<CharacterEdge>();
+        GraphQLResponse<StaffResponse>? response = null;
+        do
+        {
+            try
+            {
+                var query = $"query ($id: Int) {{ Staff (id: $id) {QueryBuilder.GetStaffCharactersQuery(page)} }}";
+                var request = new GraphQLRequest { Query = query, Variables = new { id } };
+                response = await _graphQlClient.SendQueryAsync<StaffResponse>(request);
+                mediaCount = response.Data.Staff.Characters.Edges.Length;
+                edges.AddRange(response.Data.Staff.Characters.Edges);
+
+                page++;
+            }
+            catch (Exception)
+            {
+                // What to do here? We don't really mind as we can just keep trying until the end
+            }
+        } while (mediaCount >= 25);
+
+        return (edges, response.GetRemainingLimit());
+    }
+}

--- a/Anilist4Net/Client.cs
+++ b/Anilist4Net/Client.cs
@@ -30,14 +30,31 @@ namespace Anilist4Net
 		/// </summary>
 		/// <param name="httpClient">Client instance to use for queries</param>
 		public Client(HttpClient httpClient)
-		{
+        {
+            RateLimitTimeout = TimeSpan.FromMinutes(1);
+            RateLimitTolerance = 0;
 			var options = new GraphQLHttpClientOptions
 			{
 				EndPoint = new Uri("https://graphql.anilist.co")
 			};
 			_graphQlClient = new GraphQLHttpClient(options, new SystemTextJsonSerializer(), httpClient);
 		}
-		
+
+		/// <summary>
+		/// Indicate if methods that fetch multiple pages should wait when they hit the rate limit
+		/// </summary>
+		public bool ObeyRateLimit { get; set; }
+
+		/// <summary>
+		/// The amount of time to wait if the rate limit was hit
+		/// </summary>
+		public TimeSpan RateLimitTimeout { get; set; }
+
+		/// <summary>
+		/// If the remaining rate limit entries are below this value retrieval of multiple entries will wait for rate limit recovery
+		/// </summary>
+		public int RateLimitTolerance { get; set; }
+
         #region Query Invocations
 
 		/// <summary>

--- a/Anilist4Net/Client.cs
+++ b/Anilist4Net/Client.cs
@@ -1,22 +1,19 @@
 ﻿#nullable enable
 using System.Threading.Tasks;
-using GraphQL;
 using GraphQL.Client.Http;
 using GraphQL.Client.Serializer.SystemTextJson;
 using Anilist4Net.Enums;
 using System.Net.Http;
 using System;
-using System.Net;
 using Anilist4Net.Connections;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Anilist4Net
 {
 	/// <summary>
 	/// Client used to handle retrieval of data from AniList Graph API
 	/// </summary>
-	public class Client
+	public partial class Client
 	{
 		/// <summary>
 		/// GraphQLHttpClient instance
@@ -40,7 +37,7 @@ namespace Anilist4Net
 			};
 			_graphQlClient = new GraphQLHttpClient(options, new SystemTextJsonSerializer(), httpClient);
 		}
-
+		
         #region Query Invocations
 
 		/// <summary>
@@ -49,13 +46,9 @@ namespace Anilist4Net
 		/// <param name="username">Username of the user to retrieve</param>
 		/// <returns>User data</returns>
         public async Task<User> GetUserByName(string username)
-		{
-			var query         = $"query ($username: String) {{ User (name: $username) {QueryBuilder.GetUserQuery()} }}";
-			var request       = new GraphQLRequest {Query = query, Variables = new {username}};
-			var response      = await _graphQlClient.SendQueryAsync<UserResponse>(request);
-
-			return response.Data.User;
-		}
+        {
+            return (await GetUserByNameWithRateLimit(username)).user;
+        }
 
 		/// <summary>
 		/// Retrieve a <see cref="User"/> by their AniList Id
@@ -64,11 +57,7 @@ namespace Anilist4Net
 		/// <returns>User data</returns>
 		public async Task<User> GetUserById(int id)
 		{
-			var query         = $"query ($id: Int) {{ User (id: $id) {QueryBuilder.GetUserQuery()} }}";
-			var request       = new GraphQLRequest {Query = query, Variables = new {id}};
-			var response      = await _graphQlClient.SendQueryAsync<UserResponse>(request);
-
-			return response.Data.User;
+			return (await GetUserByIdWithRateLimit(id)).user;
 		}
 
 		/// <summary>
@@ -77,29 +66,9 @@ namespace Anilist4Net
 		/// <param name="id">AniList media Id</param>
 		/// <returns>Media instance if it exists, otherwise null</returns>
 		public async Task<Media?> GetMediaById(int id)
-		{
-			var query         = $"query ($id: Int) {{ Media (id: $id) {QueryBuilder.GetMediaQuery()} }}";
-			var request       = new GraphQLRequest {Query = query, Variables = new {id}};
-			GraphQLResponse<MediaResponse> response = null!;
-			try
-			{
-				response = await _graphQlClient.SendQueryAsync<MediaResponse>(request);
-				var characterCount = response.Data.Media.Characters.Edges.Length;
-				if(characterCount >= 25)
-                {
-					var additionalCharacters = await GetAllCharactersAsync(id, 2);
-					additionalCharacters.AddRange(response.Data.Media.Characters.Edges);
-					response.Data.Media.Characters.Edges = additionalCharacters.ToArray();
-                }
-			}
-			catch (GraphQLHttpRequestException e)
-			{
-				if (e.StatusCode == HttpStatusCode.NotFound)
-					return null; // media did not exist
-			}
-
-			return response.Data.Media;
-		}
+        {
+            return (await GetMediaByIdWithRateLimit(id)).media;
+        }
 
 		/// <summary>
 		/// Retrieve a <see cref="Media"/> entry by its MyAnimeList Id.
@@ -111,30 +80,9 @@ namespace Anilist4Net
 		/// <param name="id">MAL Id to retrieve entry for</param>
 		/// <returns>Media instance if one could be found, otherwise null</returns>
 		public async Task<Media?> GetMediaByMalId(int id)
-		{
-			var query         = $"query ($id: Int) {{ Media (idMal: $id) {QueryBuilder.GetMediaQuery()} }}";
-			var request       = new GraphQLRequest {Query = query, Variables = new {id}};
-			GraphQLResponse<MediaResponse> response = null!;
-			try
-			{
-				response = await _graphQlClient.SendQueryAsync<MediaResponse>(request);
-				var characterCount = response.Data.Media.Characters.Edges.Length;
-				if (characterCount >= 25)
-				{
-					// Swap to the AniList Id rather than using the Mal Id
-					var additionalCharacters = await GetAllCharactersAsync(response.Data.Media.Id, 2);
-					additionalCharacters.AddRange(response.Data.Media.Characters.Edges);
-					response.Data.Media.Characters.Edges = additionalCharacters.ToArray();
-				}
-			}
-			catch (GraphQLHttpRequestException e)
-			{
-				if (e.StatusCode == HttpStatusCode.NotFound)
-					return null; // media did not exist
-			}
-
-			return response.Data.Media;
-		}
+        {
+            return (await GetMediaByMalIdWithRateLimit(id)).media;
+        }
 
 		/// <summary>
 		/// Retrieve a <see cref="Media"/> entry by its MyAnimeList Id and its AniList type
@@ -144,27 +92,7 @@ namespace Anilist4Net
 		/// <returns>Media instance if one could be found, otherwise null</returns>
 		public async Task<Media?> GetMediaByMalId(int id, MediaTypes mediaType)
         {
-            var query = $"query ($id: Int) {{ Media (idMal: $id type: {mediaType}) {QueryBuilder.GetMediaQuery()} }}";
-            var request = new GraphQLRequest { Query = query, Variables = new { id } };
-            GraphQLResponse<MediaResponse> response = null!;
-            try
-            {
-                response = await _graphQlClient.SendQueryAsync<MediaResponse>(request);
-				var characterCount = response.Data.Media.Characters.Edges.Length;
-				if (characterCount >= 25)
-				{
-					var additionalCharacters = await GetAllCharactersAsync(id, 2);
-					additionalCharacters.AddRange(response.Data.Media.Characters.Edges);
-					response.Data.Media.Characters.Edges = additionalCharacters.ToArray();
-				}
-			}
-            catch (GraphQLHttpRequestException e)
-            {
-                if (e.StatusCode == HttpStatusCode.NotFound)
-                    return null; // media did not exist
-            }
-
-            return response.Data.Media;
+            return (await GetMediaByMalIdWithRateLimit(id, mediaType)).media;
 		}
 
 		/// <summary>
@@ -174,27 +102,7 @@ namespace Anilist4Net
 		/// <returns>Media instance if one could be found, otherwise null</returns>
 		public async Task<Media?> GetMediaBySearch(string search)
 		{
-			var query         = $"query ($search: String) {{ Media (search: $search) {QueryBuilder.GetMediaQuery()} }}";
-			var request       = new GraphQLRequest {Query = query, Variables = new {search}};
-			GraphQLResponse<MediaResponse> response = null!;
-			try
-			{
-				response = await _graphQlClient.SendQueryAsync<MediaResponse>(request);
-				var characterCount = response.Data.Media.Characters.Edges.Length;
-				if (characterCount >= 25)
-				{
-					var additionalCharacters = await GetAllCharactersAsync(response.Data.Media.Id, 2);
-					additionalCharacters.AddRange(response.Data.Media.Characters.Edges);
-					response.Data.Media.Characters.Edges = additionalCharacters.ToArray();
-				}
-			}
-			catch (GraphQLHttpRequestException e)
-			{
-				if (e.StatusCode == HttpStatusCode.NotFound)
-					return null; // media did not exist
-			}
-
-			return response.Data.Media;
+			return (await GetMediaBySearchWithRateLimit(search)).media;
 		}
 
 		/// <summary>
@@ -205,27 +113,7 @@ namespace Anilist4Net
 		/// <returns>Media instance if one could be found, otherwise null</returns>
 		public async Task<Media?> GetMediaBySearch(string search, MediaTypes type)
 		{
-			var query         = $"query ($search: String $type: MediaType) {{ Media (search: $search type: $type) {QueryBuilder.GetMediaQuery()} }}";
-			var request       = new GraphQLRequest {Query = query, Variables = new {search, type}};
-			GraphQLResponse<MediaResponse> response = null!;
-			try
-			{
-				response = await _graphQlClient.SendQueryAsync<MediaResponse>(request);
-				var characterCount = response.Data.Media.Characters.Edges.Length;
-				if (characterCount >= 25)
-				{
-					var additionalCharacters = await GetAllCharactersAsync(response.Data.Media.Id, 2);
-					additionalCharacters.AddRange(response.Data.Media.Characters.Edges);
-					response.Data.Media.Characters.Edges = additionalCharacters.ToArray();
-				}
-			}
-			catch (GraphQLHttpRequestException e)
-			{
-				if (e.StatusCode == HttpStatusCode.NotFound)
-					return null; // media did not exist
-			}
-
-			return response.Data.Media;
+			return (await GetMediaBySearchWithRateLimit(search, type)).media;
 		}
 
 		/// <summary>
@@ -236,13 +124,9 @@ namespace Anilist4Net
 		/// <param name="perPage">The number of entries per page</param>
 		/// <returns>A paginated list of Media instances if found</returns>
 		public async Task<Page> GetMediaBySearch(string search, int page, int perPage)
-		{
-			var query         = $"query ($search: String, $page: Int, $perPage: Int) {{ Page(page: $page, perPage: $perPage) {{ {QueryBuilder.GetPageInfoQuery()} media (search: $search) {QueryBuilder.GetMediaQuery()} }} }}";
-			var request       = new GraphQLRequest {Query = query, Variables = new {search, page, perPage}};
-			var response = await _graphQlClient.SendQueryAsync<PageResponse>(request);
-			
-			return response.Data.Page;
-		}
+        {
+            return (await GetMediaBySearchWithRateLimit(search, page, perPage)).page;
+        }
 
 		/// <summary>
 		/// Search for <see cref="Media"/> entries by its title
@@ -254,11 +138,7 @@ namespace Anilist4Net
 		/// <returns>A paginated list of Media instances if found</returns>
 		public async Task<Page?> GetMediaBySearch(string search, MediaTypes type, int page, int perPage)
 		{
-			var query         = $"query ($search: String, $type: MediaType, $page: Int, $perPage: Int) {{ Page(page: $page, perPage: $perPage) {{ {QueryBuilder.GetPageInfoQuery()} media (search: $search, type: $type) {QueryBuilder.GetMediaQuery()} }} }}";
-			var request       = new GraphQLRequest {Query = query, Variables = new {search, type, page, perPage}};
-			var response = await _graphQlClient.SendQueryAsync<PageResponse>(request);
-			
-			return response.Data.Page;
+			return (await GetMediaBySearchWithRateLimit(search, type, page, perPage)).page;
 		}
 
 		/// <summary>
@@ -269,26 +149,7 @@ namespace Anilist4Net
 		/// <returns>List of <see cref="CharacterEdge"/>s for the Media</returns>
 		public async Task<List<CharacterEdge>> GetAllCharactersAsync(int id, int page)
 		{
-			var characterCount = 0;
-			var characters = new List<CharacterEdge>();
-			do
-			{
-				try
-				{
-					var query = $"query ($id: Int) {{ Media (id: $id) {QueryBuilder.GetCharactersForMediaQuery(page)} }}";
-					var request = new GraphQLRequest { Query = query, Variables = new { id } };
-					var response = await _graphQlClient.SendQueryAsync<MediaResponse>(request);
-					characterCount = response.Data.Media.Characters.Edges.Length;
-					characters.AddRange(response.Data.Media.Characters.Edges);
-					page++;
-				}
-				catch (Exception)
-				{
-					// What to do here? We don't really mind as we can just keep trying until the end
-				}
-			} while (characterCount >= 25);
-
-			return characters;
+			return (await GetAllCharactersAsyncWithRateLimit(id, page)).characters;
 		}
 
 		/// <summary>
@@ -298,11 +159,7 @@ namespace Anilist4Net
 		/// <returns>Review for the requested Id</returns>
 		public async Task<Review> GetReviewById(int id)
 		{
-			var query         = $"query ($id: Int) {{ Review (id: $id) {QueryBuilder.GetReviewQuery()} }}";
-			var request       = new GraphQLRequest {Query = query, Variables = new {id}};
-			var response      = await _graphQlClient.SendQueryAsync<ReviewResponse>(request);
-
-			return response.Data.Review;
+			return (await GetReviewByIdWithRateLimit(id)).review;
 		}
 
 		/// <summary>
@@ -311,13 +168,9 @@ namespace Anilist4Net
 		/// <param name="id">AniList Id of the schedule entry to retrieve</param>
 		/// <returns>AiringSchedule entry</returns>
 		public async Task<AiringSchedule> GetAiringScheduleById(int id)
-		{
-			var query         = $"query ($id: Int) {{ AiringSchedule (id: $id) {QueryBuilder.GetAiringScheduleQuery()} }}";
-			var request       = new GraphQLRequest {Query = query, Variables = new {id}};
-			var response      = await _graphQlClient.SendQueryAsync<AiringScheduleResponse>(request);
-
-			return response.Data.AiringSchedule;
-		}
+        {
+            return (await GetAiringScheduleByIdWithRateLimit(id)).schedule;
+        }
 
 		/// <summary>
 		/// Retrieve a <see cref="Recommendation"/> entry by its AniList Id
@@ -326,11 +179,7 @@ namespace Anilist4Net
 		/// <returns>Recommendation entry</returns>
 		public async Task<Recommendation> GetRecommendationById(int id)
 		{
-			var query         = $"query ($id: Int) {{ Recommendation (id: $id) {QueryBuilder.GetRecommendationQuery()} }}";
-			var request       = new GraphQLRequest {Query = query, Variables = new {id}};
-			var response      = await _graphQlClient.SendQueryAsync<RecommendationResponse>(request);
-
-			return response.Data.Recommendation;
+			return (await GetRecommendationByIdWithRateLimit(id)).recommendation;
 		}
 
 		/// <summary>
@@ -340,21 +189,7 @@ namespace Anilist4Net
 		/// <returns>Character entry</returns>
 		public async Task<Character> GetCharacterById(int id)
 		{
-			var query         = $"query ($id: Int) {{ Character (id: $id) {QueryBuilder.GetCharacterQuery()} }}";
-			var request       = new GraphQLRequest {Query = query, Variables = new {id}};
-			var response      = await _graphQlClient.SendQueryAsync<CharacterResponse>(request);
-
-			var mediaCount = response.Data.Character.Media.Edges.Length;
-			if (mediaCount >= 25)
-			{
-				var additionalMedia = await GetAllMediaEntriesForCharacter(id, 2);
-				additionalMedia.edges.AddRange(response.Data.Character.Media.Edges);
-				additionalMedia.nodes.AddRange(response.Data.Character.Media.Nodes);
-				response.Data.Character.Media.Edges = additionalMedia.edges.ToArray();
-				response.Data.Character.Media.Nodes = additionalMedia.nodes.ToArray();
-			}
-
-			return response.Data.Character;
+			return (await GetCharacterByIdWithRateLimit(id)).character;
 		}
 
 		/// <summary>
@@ -364,31 +199,11 @@ namespace Anilist4Net
 		/// <param name="page">Page to start the retrieval from</param>
 		/// <returns>Tuple containing a list of <see cref="MediaEdge"/>s and <see cref="MediaNodePlaceholder"/>s for the <see cref="Character"/></returns>
 		public async Task<(List<CharacterEdge> edges, List<MediaNodePlaceholder> nodes)> GetAllMediaEntriesForCharacter(int id, int page)
-		{
-			var mediaCount = 0;
-			var edges = new List<CharacterEdge>();
-			var nodes = new List<MediaNodePlaceholder>();
-			do
-			{
-				try
-				{
-					var query = $"query ($id: Int) {{ Character (id: $id) {QueryBuilder.GetCharacterMediaQuery(page)} }}";
-					var request = new GraphQLRequest { Query = query, Variables = new { id } };
-					var response = await _graphQlClient.SendQueryAsync<CharacterResponse>(request);
-					mediaCount = response.Data.Character.Media.Edges.Length;
-					edges.AddRange(response.Data.Character.Media.Edges);
-					nodes.AddRange(response.Data.Character.Media.Nodes);					
-					
-					page++;
-				}
-				catch (Exception)
-				{
-					// What to do here? We don't really mind as we can just keep trying until the end
-				}
-			} while (mediaCount >= 25);
+        {
+            var (edges, nodes, _) = await GetAllMediaEntriesForCharacterWithRateLimit(id, page);
 
 			return (edges, nodes);
-		}
+        }
 
 		/// <summary>
 		/// Search for a <see cref="Character"/>
@@ -397,11 +212,7 @@ namespace Anilist4Net
 		/// <returns>Character matching the query</returns>
 		public async Task<Character> GetCharacterBySearch(string search)
 		{
-			var query         = $"query ($search: String) {{ Character (search: $search) {QueryBuilder.GetCharacterQuery()} }}";
-			var request       = new GraphQLRequest {Query = query, Variables = new {search}};
-			var response      = await _graphQlClient.SendQueryAsync<CharacterResponse>(request);
-
-			return response.Data.Character;
+			return (await GetCharacterBySearchWithRateLimit(search)).character;
 		}
 
 		/// <summary>
@@ -411,25 +222,17 @@ namespace Anilist4Net
 		/// <returns>Studio for the Id</returns>
 		public async Task<Studio> GetStudioById(int id)
 		{
-			var query         = $"query ($id: Int) {{ Studio (id: $id) {QueryBuilder.GetStudioQuery()} }}";
-			var request       = new GraphQLRequest {Query = query, Variables = new {id}};
-			var response      = await _graphQlClient.SendQueryAsync<StudioResponse>(request);
-
-			return response.Data.Studio;
+			return (await GetStudioByIdWithRateLimit(id)).studio;
 		}
 
 		/// <summary>
 		/// Search for a <see cref="Studio"/>
 		/// </summary>
 		/// <param name="search">Search query</param>
-		/// <returns>Studio entry mathing the search query</returns>
+		/// <returns>Studio entry matching the search query</returns>
 		public async Task<Studio> GetStudioBySearch(string search)
 		{
-			var query         = $"query ($search: String) {{ Studio (search: $search) {QueryBuilder.GetStudioQuery()} }}";
-			var request       = new GraphQLRequest {Query = query, Variables = new {search}};
-			var response      = await _graphQlClient.SendQueryAsync<StudioResponse>(request);
-
-			return response.Data.Studio;
+			return (await GetStudioBySearchWithRateLimit(search)).studio;
 		}
 
 		/// <summary>
@@ -438,21 +241,9 @@ namespace Anilist4Net
 		/// <param name="id">Id of the staff entry to retrieve</param>
 		/// <returns>Staff entry for the Id</returns>
 		public async Task<Staff> GetStaffById(int id)
-		{
-			var query         = $"query ($id: Int) {{ Staff (id: $id) {QueryBuilder.GetStaffQuery()} }}";
-			var request       = new GraphQLRequest {Query = query, Variables = new {id}};
-			var response      = await _graphQlClient.SendQueryAsync<StaffResponse>(request);
-
-			var characterCount = response.Data.Staff.Characters.Edges.Length;
-			if (characterCount >= 25)
-			{
-				var additionalCharacters = await GetAllCharactersForStaffAsync(id, 2);
-				additionalCharacters.AddRange(response.Data.Staff.Characters.Edges);
-				response.Data.Staff.Characters.Edges = additionalCharacters.ToArray();
-			}
-
-			return response.Data.Staff;
-		}
+        {
+            return (await GetStaffByIdWithRateLimit(id)).staff;
+        }
 
 		/// <summary>
 		/// Search for a <see cref="Staff"/> entry
@@ -461,19 +252,7 @@ namespace Anilist4Net
 		/// <returns>Staff entry matching the search</returns>
 		public async Task<Staff> GetStaffBySearch(string search)
 		{
-			var query         = $"query ($search: String) {{ Staff (search: $search) {QueryBuilder.GetStaffQuery()} }}";
-			var request       = new GraphQLRequest {Query = query, Variables = new {search}};
-			var response      = await _graphQlClient.SendQueryAsync<StaffResponse>(request);
-
-			var characterCount = response.Data.Staff.Characters.Edges.Length;
-			if (characterCount >= 25)
-			{
-				var additionalCharacters = await GetAllCharactersForStaffAsync(response.Data.Staff.Id, 2);
-				additionalCharacters.AddRange(response.Data.Staff.Characters.Edges);
-				response.Data.Staff.Characters.Edges = additionalCharacters.ToArray();
-			}
-
-			return response.Data.Staff;
+			return (await GetStaffBySearchWithRateLimit(search)).staff;
 		}
 
         /// <summary>
@@ -485,11 +264,7 @@ namespace Anilist4Net
         /// <returns>Media for the requested season</returns>
         public async Task<Page> GetMediaForSeason(int page, Seasons season, int seasonYear)
         {
-            var query         = $"query ($page: Int $season: MediaSeason, $seasonYear: Int) {{ Page (page: $page) {{ media (season: $season seasonYear: $seasonYear) {QueryBuilder.GetSeasonQuery()} }}}}";
-            var request       = new GraphQLRequest { Query = query, Variables = new { page, season, seasonYear } };
-            var response      = await _graphQlClient.SendQueryAsync<PageResponse>(request);
-
-            return response.Data.Page;
+            return (await GetMediaForSeasonWithRateLimit(page, season, seasonYear)).page;
         }
 
         /// <summary>
@@ -499,29 +274,9 @@ namespace Anilist4Net
         /// <param name="page">Page to start the retrieval from</param>
         /// <returns>List of <see cref="MediaEdge"/>s for the <see cref="Staff"/></returns>
         public async Task<List<CharacterEdge>> GetAllCharactersForStaffAsync(int id, int page)
-		{
-			var mediaCount = 0;
-			var edges = new List<CharacterEdge>();
-			do
-			{
-				try
-				{
-					var query = $"query ($id: Int) {{ Staff (id: $id) {QueryBuilder.GetStaffCharactersQuery(page)} }}";
-					var request = new GraphQLRequest { Query = query, Variables = new { id } };
-					var response = await _graphQlClient.SendQueryAsync<StaffResponse>(request);
-					mediaCount = response.Data.Staff.Characters.Edges.Length;
-					edges.AddRange(response.Data.Staff.Characters.Edges);
-
-					page++;
-				}
-				catch (Exception)
-				{
-					// What to do here? We don't really mind as we can just keep trying until the end
-				}
-			} while (mediaCount >= 25);
-
-			return edges;
-		}
+        {
+            return (await GetAllCharactersForStaffWithRateLimitAsync(id, page)).characters;
+        }
 
 		#endregion
 	}

--- a/Anilist4Net/Extensions.cs
+++ b/Anilist4Net/Extensions.cs
@@ -1,0 +1,47 @@
+﻿using System.Linq;
+using GraphQL;
+using GraphQL.Client.Http;
+
+namespace Anilist4Net;
+
+/// <summary>
+/// Contains extension methods
+/// </summary>
+public static class Extensions
+{
+    /// <summary>
+    /// Get the remaining rate limit value from the <see cref="GraphQLResponse{T}"/>
+    /// </summary>
+    /// <typeparam name="T">The class for the response type</typeparam>
+    /// <param name="graphQlResponse">The response to pull the limit from</param>
+    /// <returns>The remaining rate limit value</returns>
+    public static int GetRemainingLimit<T>(this GraphQLResponse<T> graphQlResponse) where T : class
+    {
+        if (graphQlResponse is GraphQLHttpResponse<T> httpResponse)
+        {
+            var limit = httpResponse.ResponseHeaders.FirstOrDefault(x => x.Key == "X-RateLimit-Remaining");
+            if (int.TryParse(limit.Value?.FirstOrDefault(), out var remaining))
+            {
+                return remaining;
+            }
+        }
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Get the remaining rate limit value from a <see cref="GraphQLHttpRequestException"/>
+    /// </summary>
+    /// <param name="exception">Exception to pull the limit from</param>
+    /// <returns>The remaining rate limit value</returns>
+    public static int GetRemainingLimit(this GraphQLHttpRequestException exception)
+    {
+        var limit = exception.ResponseHeaders.FirstOrDefault(x => x.Key == "X-RateLimit-Remaining");
+        if (int.TryParse(limit.Value?.FirstOrDefault(), out var remaining))
+        {
+            return remaining;
+        }
+
+        return 0;
+    }
+}


### PR DESCRIPTION
Updated the Client class so all methods support returning the remaining requests before being rate limited.
Also added a switch, timeout and tolerance to allow multi retrievals to delay themselves when the remaining requests drop below the user defined tolerance.

The change will be invisible to existing users as the original methods were left intact, they call the new rate limit returning methods and discard the rate limit. By default the "ObeyRateLimit" switch is set to false so the original handling of the batch retrieval methods remain intact.